### PR TITLE
general fuzz seeder

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -78,7 +78,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             seed,
         } => {
             let testfile = TestConfig::from_file(&testfile)?;
-            let spammer = Spammer::new(testfile, rpc_url, seed.map(|s| RandSeed::from_str(&s)));
+            let rand_seed = seed.map(|s| RandSeed::from_str(&s)).unwrap_or_default();
+            let spammer = Spammer::new(testfile, rpc_url, rand_seed);
             spammer.spam_rpc(intensity.unwrap_or_default(), duration.unwrap_or_default())?;
         }
         ContenderSubcommand::Report { id, out_file } => {

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -1,6 +1,9 @@
 use clap::{Parser, Subcommand};
 use contender_core::{
-    generator::{test_config::TestConfig, RandSeed},
+    generator::{
+        test_config::{TestConfig, TestGenerator},
+        RandSeed,
+    },
     spammer::Spammer,
 };
 
@@ -79,7 +82,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         } => {
             let testfile = TestConfig::from_file(&testfile)?;
             let rand_seed = seed.map(|s| RandSeed::from_str(&s)).unwrap_or_default();
-            let spammer = Spammer::new(testfile, rpc_url, rand_seed);
+            let testgen = TestGenerator::new(testfile, &rand_seed);
+            let spammer = Spammer::new(testgen, rpc_url);
             spammer.spam_rpc(intensity.unwrap_or_default(), duration.unwrap_or_default())?;
         }
         ContenderSubcommand::Report { id, out_file } => {

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -1,6 +1,6 @@
 use clap::{Parser, Subcommand};
 use contender_core::{
-    generator::{rand_seed::RandSeed, test_config::TestConfig},
+    generator::{test_config::TestConfig, RandSeed},
     spammer::Spammer,
 };
 

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -78,12 +78,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             seed,
         } => {
             let testfile = TestConfig::from_file(&testfile)?;
-            let spammer = Spammer::new(
-                testfile,
-                rpc_url,
-                seed.map(|s| RandSeed::from_str(&s)),
-                None,
-            );
+            let spammer = Spammer::new(testfile, rpc_url, seed.map(|s| RandSeed::from_str(&s)));
             spammer.spam_rpc(intensity.unwrap_or_default(), duration.unwrap_or_default())?;
         }
         ContenderSubcommand::Report { id, out_file } => {

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -1,6 +1,7 @@
 use crate::Result;
 use alloy::rpc::types::TransactionRequest;
-use rand_seed::RandSeed;
+pub use rand_seed::RandSeed;
+use rand_seed::Seeder;
 
 pub mod rand_seed;
 pub mod test_config;
@@ -8,10 +9,6 @@ pub mod univ2;
 
 /// Implement Generator to programmatically
 /// generate transactions for advanced testing scenarios.
-pub trait Generator {
-    fn get_spam_txs(
-        &self,
-        amount: usize,
-        seed: Option<RandSeed>,
-    ) -> Result<Vec<TransactionRequest>>;
+pub trait Generator<T: Seeder> {
+    fn get_spam_txs(&self, amount: usize, seed: &T) -> Result<Vec<TransactionRequest>>;
 }

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -1,7 +1,6 @@
 use crate::Result;
 use alloy::rpc::types::TransactionRequest;
 pub use seeder::rand_seed::RandSeed;
-use seeder::Seeder;
 
 pub mod seeder;
 pub mod test_config;
@@ -9,6 +8,6 @@ pub mod univ2;
 
 /// Implement Generator to programmatically
 /// generate transactions for advanced testing scenarios.
-pub trait Generator<T: Seeder> {
-    fn get_spam_txs(&self, amount: usize, seed: &T) -> Result<Vec<TransactionRequest>>;
+pub trait Generator {
+    fn get_spam_txs(&self, amount: usize) -> Result<Vec<TransactionRequest>>;
 }

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -1,9 +1,9 @@
 use crate::Result;
 use alloy::rpc::types::TransactionRequest;
-pub use rand_seed::RandSeed;
-use rand_seed::Seeder;
+pub use seeder::rand_seed::RandSeed;
+use seeder::Seeder;
 
-pub mod rand_seed;
+pub mod seeder;
 pub mod test_config;
 pub mod univ2;
 

--- a/src/generator/rand_seed.rs
+++ b/src/generator/rand_seed.rs
@@ -1,9 +1,26 @@
-use alloy::primitives::U256;
+use alloy::primitives::{keccak256, U256};
 use rand::Rng;
 
+pub trait Seeder {
+    fn seed_values(
+        &self,
+        amount: usize,
+        min: Option<U256>,
+        max: Option<U256>,
+    ) -> Box<Vec<impl SeedValue>>;
+}
+
+pub trait SeedValue {
+    fn as_bytes(&self) -> &[u8];
+    fn as_u64(&self) -> u64;
+    fn as_u128(&self) -> u128;
+    fn as_u256(&self) -> U256;
+}
+
+/// Default seed generator, using a random 32-byte seed.
 #[derive(Debug, Clone)]
 pub struct RandSeed {
-    pub seed: [u8; 32],
+    seed: [u8; 32],
 }
 
 impl RandSeed {
@@ -26,20 +43,51 @@ impl RandSeed {
         Self { seed: seed_arr }
     }
 
-    pub fn as_bytes(&self) -> &[u8] {
+    pub fn from_u256(seed: U256) -> Self {
+        Self {
+            seed: seed.to_le_bytes(),
+        }
+    }
+}
+
+impl SeedValue for RandSeed {
+    fn as_bytes(&self) -> &[u8] {
         &self.seed
     }
 
-    pub fn as_u64(&self) -> u64 {
+    fn as_u64(&self) -> u64 {
         u64::from_le_bytes(self.seed[0..8].try_into().unwrap())
     }
 
-    pub fn as_u128(&self) -> u128 {
+    fn as_u128(&self) -> u128 {
         u128::from_le_bytes(self.seed[0..16].try_into().unwrap())
     }
 
-    pub fn as_u256(&self) -> U256 {
+    fn as_u256(&self) -> U256 {
         U256::from_le_bytes::<32>(self.seed.try_into().unwrap())
+    }
+}
+
+impl Seeder for RandSeed {
+    fn seed_values(
+        &self,
+        amount: usize,
+        min: Option<U256>,
+        max: Option<U256>,
+    ) -> Box<Vec<impl SeedValue>> {
+        let min = min.unwrap_or(U256::ZERO);
+        let max = max.unwrap_or(U256::MAX);
+        let vals = (0..amount)
+            .map(move |i| {
+                // generate random-looking value between min and max from seed
+                let seed_num = self.as_u256() + U256::from(i);
+                let val = keccak256(seed_num.as_le_slice());
+                let val = U256::from_le_bytes(val.0);
+                let val = val % (max - min) + min;
+                RandSeed::from_u256(val)
+            })
+            .collect::<Vec<RandSeed>>();
+        Box::new(vals.to_owned())
     }
 }
 

--- a/src/generator/seeder/mod.rs
+++ b/src/generator/seeder/mod.rs
@@ -7,7 +7,7 @@ pub trait Seeder {
         amount: usize,
         min: Option<U256>,
         max: Option<U256>,
-    ) -> Box<Vec<impl SeedValue>>;
+    ) -> Box<impl Iterator<Item = impl SeedValue>>;
 }
 
 pub trait SeedValue {

--- a/src/generator/seeder/mod.rs
+++ b/src/generator/seeder/mod.rs
@@ -1,0 +1,18 @@
+pub mod rand_seed;
+use alloy::primitives::U256;
+
+pub trait Seeder {
+    fn seed_values(
+        &self,
+        amount: usize,
+        min: Option<U256>,
+        max: Option<U256>,
+    ) -> Box<Vec<impl SeedValue>>;
+}
+
+pub trait SeedValue {
+    fn as_bytes(&self) -> &[u8];
+    fn as_u64(&self) -> u64;
+    fn as_u128(&self) -> u128;
+    fn as_u256(&self) -> U256;
+}

--- a/src/generator/seeder/rand_seed.rs
+++ b/src/generator/seeder/rand_seed.rs
@@ -8,6 +8,16 @@ pub struct RandSeed {
     seed: [u8; 32],
 }
 
+fn fill_bytes(seed: &[u8], target: &mut [u8; 32]) {
+    if seed.len() < 32 {
+        // right-pad with one-bytes
+        target[0..seed.len()].copy_from_slice(seed);
+        target[seed.len()..32].fill(0x01);
+    } else {
+        target.copy_from_slice(&seed[0..32]);
+    }
+}
+
 impl RandSeed {
     pub fn new() -> Self {
         let mut rng = rand::thread_rng();
@@ -16,16 +26,14 @@ impl RandSeed {
         Self { seed }
     }
 
-    pub fn from_bytes(seed: &[u8]) -> Self {
+    pub fn from_bytes(seed_bytes: &[u8]) -> Self {
         let mut seed_arr = [0u8; 32];
-        seed_arr.copy_from_slice(seed);
+        fill_bytes(seed_bytes, &mut seed_arr);
         Self { seed: seed_arr }
     }
 
     pub fn from_str(seed: &str) -> Self {
-        let mut seed_arr = [0u8; 32];
-        seed_arr.copy_from_slice(seed.as_bytes());
-        Self { seed: seed_arr }
+        RandSeed::from_bytes(seed.as_bytes())
     }
 
     pub fn from_u256(seed: U256) -> Self {

--- a/src/generator/seeder/rand_seed.rs
+++ b/src/generator/seeder/rand_seed.rs
@@ -59,19 +59,17 @@ impl Seeder for RandSeed {
         amount: usize,
         min: Option<U256>,
         max: Option<U256>,
-    ) -> Box<Vec<impl SeedValue>> {
+    ) -> Box<impl Iterator<Item = impl SeedValue>> {
         let min = min.unwrap_or(U256::ZERO);
         let max = max.unwrap_or(U256::MAX);
-        let vals = (0..amount)
-            .map(move |i| {
-                // generate random-looking value between min and max from seed
-                let seed_num = self.as_u256() + U256::from(i);
-                let val = keccak256(seed_num.as_le_slice());
-                let val = U256::from_le_bytes(val.0);
-                let val = val % (max - min) + min;
-                RandSeed::from_u256(val)
-            })
-            .collect::<Vec<RandSeed>>();
+        let vals = (0..amount).map(move |i| {
+            // generate random-looking value between min and max from seed
+            let seed_num = self.as_u256() + U256::from(i);
+            let val = keccak256(seed_num.as_le_slice());
+            let val = U256::from_le_bytes(val.0);
+            let val = val % (max - min) + min;
+            RandSeed::from_u256(val)
+        });
         Box::new(vals.to_owned())
     }
 }

--- a/src/generator/seeder/rand_seed.rs
+++ b/src/generator/seeder/rand_seed.rs
@@ -8,9 +8,9 @@ pub struct RandSeed {
     seed: [u8; 32],
 }
 
+/// Copies `seed` into `target` and right-pads with `0x01` to 32 bytes.
 fn fill_bytes(seed: &[u8], target: &mut [u8; 32]) {
     if seed.len() < 32 {
-        // right-pad with one-bytes
         target[0..seed.len()].copy_from_slice(seed);
         target[seed.len()..32].fill(0x01);
     } else {
@@ -26,19 +26,31 @@ impl RandSeed {
         Self { seed }
     }
 
+    /// Interprets `seed` as a byte array.
+    /// - If `seed` is less than 32 bytes, it is right-padded with 0x01.
+    /// - If `seed` is more than 32 bytes, only the first 32 bytes are used.
+    /// - Number types created from these bytes are interpreted as big-endian.
     pub fn from_bytes(seed_bytes: &[u8]) -> Self {
         let mut seed_arr = [0u8; 32];
         fill_bytes(seed_bytes, &mut seed_arr);
         Self { seed: seed_arr }
     }
 
+    /// Interprets seed as a number in base 10 or 16.
     pub fn from_str(seed: &str) -> Self {
-        RandSeed::from_bytes(seed.as_bytes())
+        let (radix, seed) = if seed.starts_with("0x") {
+            (16u64, seed.split_at(2).1)
+        } else {
+            (10u64, seed)
+        };
+        let n =
+            U256::from_str_radix(seed, radix).expect("invalid seed number; must fit in 32 bytes");
+        Self::from_u256(n)
     }
 
     pub fn from_u256(seed: U256) -> Self {
         Self {
-            seed: seed.to_le_bytes(),
+            seed: seed.to_be_bytes(),
         }
     }
 }
@@ -49,15 +61,19 @@ impl SeedValue for RandSeed {
     }
 
     fn as_u64(&self) -> u64 {
-        u64::from_le_bytes(self.seed[0..8].try_into().unwrap())
+        let mut seed: [u8; 8] = [0; 8];
+        seed.copy_from_slice(&self.seed[24..32]);
+        u64::from_be_bytes(seed)
     }
 
     fn as_u128(&self) -> u128 {
-        u128::from_le_bytes(self.seed[0..16].try_into().unwrap())
+        let mut seed: [u8; 16] = [0; 16];
+        seed.copy_from_slice(&self.seed[16..32]);
+        u128::from_be_bytes(seed)
     }
 
     fn as_u256(&self) -> U256 {
-        U256::from_le_bytes::<32>(self.seed.try_into().unwrap())
+        U256::from_be_bytes::<32>(self.seed)
     }
 }
 
@@ -74,7 +90,7 @@ impl Seeder for RandSeed {
             // generate random-looking value between min and max from seed
             let seed_num = self.as_u256() + U256::from(i);
             let val = keccak256(seed_num.as_le_slice());
-            let val = U256::from_le_bytes(val.0);
+            let val = U256::from_be_bytes(val.0);
             let val = val % (max - min) + min;
             RandSeed::from_u256(val)
         });
@@ -85,5 +101,41 @@ impl Seeder for RandSeed {
 impl Default for RandSeed {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::hex::ToHexExt;
+
+    use super::U256;
+    use crate::generator::seeder::SeedValue;
+
+    #[test]
+    fn encodes_seed_bytes() {
+        let mut seed_bytes = [0u8; 32];
+        seed_bytes[seed_bytes.len() - 1] = 0x01;
+        println!("{}", seed_bytes.encode_hex());
+        let seed = super::RandSeed::from_bytes(&seed_bytes);
+        println!("{}", seed.as_bytes().encode_hex());
+        assert_eq!(seed.as_bytes().len(), 32);
+        assert_eq!(seed.as_u64(), 1);
+        assert_eq!(seed.as_u128(), 1);
+        assert_eq!(seed.as_u256(), U256::from(1));
+    }
+
+    #[test]
+    fn encodes_seed_string() {
+        let seed = super::RandSeed::from_str("0x01");
+        assert_eq!(seed.as_u64(), 1);
+        assert_eq!(seed.as_u128(), 1);
+        assert_eq!(seed.as_u256(), U256::from(1));
+    }
+
+    #[test]
+    fn encodes_seed_u256() {
+        let n = U256::MAX;
+        let seed = super::RandSeed::from_u256(n);
+        assert_eq!(seed.as_u256(), n);
     }
 }

--- a/src/generator/seeder/rand_seed.rs
+++ b/src/generator/seeder/rand_seed.rs
@@ -1,21 +1,6 @@
+use super::{SeedValue, Seeder};
 use alloy::primitives::{keccak256, U256};
 use rand::Rng;
-
-pub trait Seeder {
-    fn seed_values(
-        &self,
-        amount: usize,
-        min: Option<U256>,
-        max: Option<U256>,
-    ) -> Box<Vec<impl SeedValue>>;
-}
-
-pub trait SeedValue {
-    fn as_bytes(&self) -> &[u8];
-    fn as_u64(&self) -> u64;
-    fn as_u128(&self) -> u128;
-    fn as_u256(&self) -> U256;
-}
 
 /// Default seed generator, using a random 32-byte seed.
 #[derive(Debug, Clone)]

--- a/src/generator/test_config.rs
+++ b/src/generator/test_config.rs
@@ -11,6 +11,11 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::read;
 
+pub struct TestGenerator<'a, T: Seeder> {
+    config: TestConfig,
+    seed: &'a T,
+}
+
 /// Testfile
 #[derive(Deserialize, Debug, Serialize)]
 pub struct TestConfig {
@@ -42,6 +47,15 @@ pub struct FuzzParam {
     pub max: Option<U256>,
 }
 
+impl<'a, T> TestGenerator<'a, T>
+where
+    T: Seeder,
+{
+    pub fn new(config: TestConfig, seed: &'a T) -> Self {
+        Self { config, seed }
+    }
+}
+
 impl TestConfig {
     pub fn from_file(file_path: &str) -> Result<TestConfig, Box<dyn std::error::Error>> {
         let file_contents = read(file_path)?;
@@ -62,18 +76,14 @@ impl TestConfig {
     }
 }
 
-impl<T> Generator<T> for TestConfig
+impl<'a, T> Generator for TestGenerator<'a, T>
 where
     T: Seeder,
 {
-    fn get_spam_txs(
-        &self,
-        amount: usize,
-        seed: &T,
-    ) -> Result<Vec<TransactionRequest>, ContenderError> {
+    fn get_spam_txs(&self, amount: usize) -> Result<Vec<TransactionRequest>, ContenderError> {
         let mut templates = Vec::new();
 
-        if let Some(function) = &self.function {
+        if let Some(function) = &self.config.function {
             let func = alloy_json_abi::Function::parse(&function.signature).map_err(|e| {
                 ContenderError::SpamError("failed to parse function name", Some(e.to_string()))
             })?;
@@ -85,7 +95,8 @@ where
             if let Some(fuzz_params) = function.fuzz.as_ref() {
                 // NOTE: This will only generate a single 32-byte value for each fuzzed parameter. Fuzzing values in arrays/structs is not yet supported.
                 for fparam in fuzz_params.iter() {
-                    let values = seed
+                    let values = self
+                        .seed
                         .seed_values(amount, fparam.min, fparam.max)
                         .map(|v| v.as_u256())
                         .collect::<Vec<U256>>();
@@ -130,7 +141,7 @@ where
                     })?;
 
                 let tx = alloy::rpc::types::TransactionRequest {
-                    to: Some(alloy::primitives::TxKind::Call(self.to.clone())),
+                    to: Some(alloy::primitives::TxKind::Call(self.config.to.clone())),
                     input: alloy::rpc::types::TransactionInput::both(input.into()),
                     ..Default::default()
                 };
@@ -220,9 +231,10 @@ mod tests {
     #[test]
     fn gets_spam_txs() {
         let test_file = get_testconfig();
-        // this seed can be used to recreate the same test tx(s)
         let seed = RandSeed::new();
-        let spam_txs = test_file.get_spam_txs(1, &seed).unwrap();
+        let test_gen = TestGenerator::new(test_file, &seed);
+        // this seed can be used to recreate the same test tx(s)
+        let spam_txs = test_gen.get_spam_txs(1).unwrap();
         println!("generated test tx(s): {:?}", spam_txs);
         assert_eq!(spam_txs.len(), 1);
         let data = spam_txs[0].input.input.to_owned().unwrap().to_string();
@@ -233,9 +245,10 @@ mod tests {
     fn fuzz_is_deterministic() {
         let test_file = get_fuzzy_testconfig();
         let seed = RandSeed::from_bytes(&[0x01; 32]);
+        let test_gen = TestGenerator::new(test_file, &seed);
         let num_txs = 3;
-        let spam_txs_1 = test_file.get_spam_txs(num_txs, &seed).unwrap();
-        let spam_txs_2 = test_file.get_spam_txs(num_txs, &seed).unwrap();
+        let spam_txs_1 = test_gen.get_spam_txs(num_txs).unwrap();
+        let spam_txs_2 = test_gen.get_spam_txs(num_txs).unwrap();
         for i in 0..num_txs {
             let data1 = spam_txs_1[i].input.input.to_owned().unwrap().to_string();
             let data2 = spam_txs_2[i].input.input.to_owned().unwrap().to_string();

--- a/src/generator/test_config.rs
+++ b/src/generator/test_config.rs
@@ -87,7 +87,6 @@ where
                 for fparam in fuzz_params.iter() {
                     let values = seed
                         .seed_values(amount, fparam.min, fparam.max)
-                        .into_iter()
                         .map(|v| v.as_u256())
                         .collect::<Vec<U256>>();
                     map.insert(fparam.name.to_owned(), values);

--- a/src/generator/test_config.rs
+++ b/src/generator/test_config.rs
@@ -1,6 +1,8 @@
-use super::{rand_seed::Seeder, Generator};
 use crate::error::ContenderError;
-use crate::generator::rand_seed::SeedValue;
+use crate::generator::{
+    seeder::{SeedValue, Seeder},
+    Generator,
+};
 use alloy::{
     primitives::{Address, U256},
     rpc::types::TransactionRequest,

--- a/src/generator/univ2.rs
+++ b/src/generator/univ2.rs
@@ -8,8 +8,7 @@ use alloy::sol;
 use alloy::sol_types::SolCall;
 use lazy_static::lazy_static;
 
-use super::rand_seed::RandSeed;
-use super::Generator;
+use super::{Generator, RandSeed};
 
 pub struct UniV2Spammer;
 
@@ -68,12 +67,12 @@ fn tx_add_liquidity(
     })
 }
 
-impl Generator for UniV2Spammer {
+impl Generator<RandSeed> for UniV2Spammer {
     fn get_spam_txs(
         &self,
         // TODO: implement these params
         _amount: usize,
-        _seed: Option<RandSeed>,
+        _seed: &RandSeed,
     ) -> Result<Vec<TransactionRequest>> {
         let token_a = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
             .parse::<Address>()

--- a/src/generator/univ2.rs
+++ b/src/generator/univ2.rs
@@ -1,14 +1,11 @@
-use std::time::{SystemTime, UNIX_EPOCH};
-
-/// this module implements an interface for Uniswap V2 Router02 transactions
+use super::Generator;
 use crate::Result;
 use alloy::primitives::{Address, TxKind, U256};
 use alloy::rpc::types::{TransactionInput, TransactionRequest};
 use alloy::sol;
 use alloy::sol_types::SolCall;
 use lazy_static::lazy_static;
-
-use super::{Generator, RandSeed};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 pub struct UniV2Spammer;
 
@@ -67,12 +64,11 @@ fn tx_add_liquidity(
     })
 }
 
-impl Generator<RandSeed> for UniV2Spammer {
+impl Generator for UniV2Spammer {
     fn get_spam_txs(
         &self,
         // TODO: implement these params
         _amount: usize,
-        _seed: &RandSeed,
     ) -> Result<Vec<TransactionRequest>> {
         let token_a = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
             .parse::<Address>()

--- a/src/spammer/mod.rs
+++ b/src/spammer/mod.rs
@@ -3,7 +3,6 @@ use crate::{
     Result,
 };
 use alloy::{
-    primitives::FixedBytes,
     providers::Provider,
     transports::http::{reqwest::Url, Http},
 };
@@ -17,19 +16,13 @@ pub struct Spammer<G: Generator> {
     generator: G,
     rpc_client: Box<RootProvider<Http<Client>>>,
     seed: RandSeed,
-    // TODO: add signer for priv_key tx signatures
 }
 
 impl<G> Spammer<G>
 where
     G: Generator,
 {
-    pub fn new(
-        generator: G,
-        rpc_url: impl AsRef<str>,
-        seed: Option<RandSeed>,
-        priv_key: Option<FixedBytes<32>>,
-    ) -> Self {
+    pub fn new(generator: G, rpc_url: impl AsRef<str>, seed: Option<RandSeed>) -> Self {
         let seed = seed.unwrap_or_default();
         let rpc_client =
             ProviderBuilder::new().on_http(Url::parse(rpc_url.as_ref()).expect("Invalid RPC URL"));

--- a/src/spammer/mod.rs
+++ b/src/spammer/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    generator::{rand_seed::Seeder, Generator},
+    generator::{seeder::Seeder, Generator},
     Result,
 };
 use alloy::{


### PR DESCRIPTION
- New traits `Seeder` and `SeedValue` allow devs to implement their own number-generators to use
- removed `Seeder` type bounds from `Spammer` and `Generator`
  - Not all generators need seeders, so it's up to the writer of `impl Generator for YourStructHere` to manage their own `Seeder` (if they need one).
- `Spammer`'s implementation now only relies on an `impl Generator`.

A prime example of a `Generator` implementation is [here](https://github.com/zeroXbrock/contender/blob/general-fuzz-seeder/src/generator/test_config.rs#L79) -- this is used to generate txs from a [config file](https://github.com/zeroXbrock/contender/blob/general-fuzz-seeder/univ2ConfigTest.toml). 

