### PR TITLE
change callback args; tx_req, hashmap

### DIFF
--- a/src/spammer/blockwise.rs
+++ b/src/spammer/blockwise.rs
@@ -21,7 +21,7 @@ pub struct BlockwiseSpammer<F, D, S, P>
 where
     D: DbOps + Send + Sync + 'static,
     S: Seeder + Send + Sync,
-    F: OnTxSent<String> + Send + Sync + 'static,
+    F: OnTxSent + Send + Sync + 'static,
     P: PlanConfig<String> + Templater<String> + Send + Sync,
 {
     scenario: TestScenario<D, S, P>,

--- a/src/spammer/blockwise.rs
+++ b/src/spammer/blockwise.rs
@@ -31,7 +31,7 @@ where
 
 impl<F, D, S, P> BlockwiseSpammer<F, D, S, P>
 where
-    F: OnTxSent<String> + Send + Sync + 'static,
+    F: OnTxSent + Send + Sync + 'static,
     D: DbOps + Send + Sync + 'static,
     S: Seeder + Send + Sync,
     P: PlanConfig<String> + Templater<String> + Send + Sync,

--- a/src/spammer/mod.rs
+++ b/src/spammer/mod.rs
@@ -2,12 +2,24 @@ pub mod blockwise;
 pub mod timed;
 pub mod util;
 
+use std::collections::HashMap;
+
 use alloy::primitives::TxHash;
 use tokio::task::JoinHandle;
 
 pub use blockwise::BlockwiseSpammer;
 pub use timed::TimedSpammer;
 
-pub trait OnTxSent {
-    fn on_tx_sent(&self, tx_hash: TxHash, name: Option<String>) -> Option<JoinHandle<()>>;
+use crate::generator::NamedTxRequest;
+
+pub trait OnTxSent<K = String>
+where
+    K: Eq + std::hash::Hash + AsRef<str>,
+{
+    fn on_tx_sent(
+        &self,
+        tx_hash: TxHash,
+        req: NamedTxRequest,
+        extra: Option<HashMap<K, String>>,
+    ) -> Option<JoinHandle<()>>;
 }

--- a/src/spammer/mod.rs
+++ b/src/spammer/mod.rs
@@ -12,14 +12,15 @@ pub use timed::TimedSpammer;
 
 use crate::generator::NamedTxRequest;
 
-pub trait OnTxSent<K = String>
+pub trait OnTxSent<K = String, V = String>
 where
     K: Eq + std::hash::Hash + AsRef<str>,
+    V: AsRef<str>,
 {
     fn on_tx_sent(
         &self,
         tx_hash: TxHash,
         req: NamedTxRequest,
-        extra: Option<HashMap<K, String>>,
+        extra: Option<HashMap<K, V>>,
     ) -> Option<JoinHandle<()>>;
 }

--- a/src/spammer/timed.rs
+++ b/src/spammer/timed.rs
@@ -77,8 +77,11 @@ where
                         .map(|s| s.encode_hex())
                         .unwrap_or_default(),
                 );
-                let res = rpc_client.send_transaction(tx.tx).await.unwrap();
-                let maybe_handle = callback_handler.on_tx_sent(*res.tx_hash(), tx.name);
+                let res = rpc_client
+                    .send_transaction(tx_req.to_owned())
+                    .await
+                    .unwrap();
+                let maybe_handle = callback_handler.on_tx_sent(*res.tx_hash(), tx, None);
                 if let Some(handle) = maybe_handle {
                     handle.await.unwrap();
                 } // ignore None values so we don't attempt to await them

--- a/src/spammer/util.rs
+++ b/src/spammer/util.rs
@@ -1,13 +1,20 @@
 #[cfg(test)]
 pub mod test {
+    use std::collections::HashMap;
+
     use alloy::primitives::TxHash;
     use tokio::task::JoinHandle;
 
-    use crate::spammer::OnTxSent;
+    use crate::{generator::NamedTxRequest, spammer::OnTxSent};
 
     pub struct MockCallback;
-    impl OnTxSent for MockCallback {
-        fn on_tx_sent(&self, _tx_hash: TxHash, _name: Option<String>) -> Option<JoinHandle<()>> {
+    impl OnTxSent<String> for MockCallback {
+        fn on_tx_sent(
+            &self,
+            _tx_hash: TxHash,
+            _req: NamedTxRequest,
+            _extra: Option<HashMap<String, String>>,
+        ) -> Option<JoinHandle<()>> {
             println!("MockCallback::on_tx_sent: tx_hash={}", _tx_hash);
             None
         }


### PR DESCRIPTION
gives some flexibility to the callback by adding a hashmap along with the original named tx request to its params.