### PR TITLE
set-chain-id tweaks

### DIFF
--- a/src/spammer/blockwise.rs
+++ b/src/spammer/blockwise.rs
@@ -63,13 +63,19 @@ where
             .collect();
         let mut block_offset = 0;
 
+        // get chain id before we start spamming
+        let chain_id = self
+            .rpc_client
+            .get_chain_id()
+            .await
+            .map_err(|e| ContenderError::with_err(e, "failed to get chain id"))?;
+
         // init block stream
-        let poller = self.rpc_client.watch_blocks().await.map_err(|e| {
-            crate::error::ContenderError::SpamError(
-                "failed to create block poller",
-                e.to_string().into(),
-            )
-        })?;
+        let poller = self
+            .rpc_client
+            .watch_blocks()
+            .await
+            .map_err(|e| ContenderError::with_err(e, "failed to create block poller"))?;
         let mut stream = poller
             .into_stream()
             .flat_map(futures::stream::iter)
@@ -83,9 +89,11 @@ where
             block_offset += 1;
 
             // get gas price
-            let gas_price = self.rpc_client.get_gas_price().await.map_err(|e| {
-                ContenderError::SpamError("failed to get gas price", e.to_string().into())
-            })?;
+            let gas_price = self
+                .rpc_client
+                .get_gas_price()
+                .await
+                .map_err(|e| ContenderError::with_err(e, "failed to get gas price"))?;
             // get nonce for each signer and put it into a hashmap
             let mut nonces = HashMap::new();
             for (addr, _) in self.scenario.wallet_map.iter() {
@@ -135,12 +143,7 @@ where
                         .rpc_client
                         .estimate_gas(&tx.tx.to_owned())
                         .await
-                        .map_err(|e| {
-                            ContenderError::SpamError(
-                                "failed to estimate gas",
-                                e.to_string().into(),
-                            )
-                        })?;
+                        .map_err(|e| ContenderError::with_err(e, "failed to estimate gas"))?;
                     gas_limits.insert(fn_sig, gas_limit);
                 }
 
@@ -168,8 +171,6 @@ where
                     let provider = ProviderBuilder::new()
                         .wallet(signer)
                         .on_provider(rpc_client);
-
-                    let chain_id = provider.get_chain_id().await.expect("failed to get chain id");
 
                     let full_tx = tx_req
                         .clone()

--- a/src/spammer/blockwise.rs
+++ b/src/spammer/blockwise.rs
@@ -169,10 +169,13 @@ where
                         .wallet(signer)
                         .on_provider(rpc_client);
 
+                    let chain_id = provider.get_chain_id().await.expect("failed to get chain id");
+
                     let full_tx = tx_req
                         .clone()
                         .with_nonce(nonce)
                         .with_gas_price(gas_price)
+                        .with_chain_id(chain_id)
                         .with_gas_limit(gas_limit);
 
                     let res = provider.send_transaction(full_tx).await.unwrap();

--- a/src/test_scenario.rs
+++ b/src/test_scenario.rs
@@ -87,6 +87,7 @@ where
 
             println!("deploying contract: {:?}", tx_req.name);
             let handle = tokio::task::spawn(async move {
+                let chain_id = provider.get_chain_id().await.expect("failed to get chain id");
                 // estimate gas limit
                 let gas_limit = provider
                     .estimate_gas(&tx_req.tx)
@@ -97,6 +98,7 @@ where
                 let tx = tx_req
                     .tx
                     .with_gas_price(gas_price)
+                    .with_chain_id(chain_id)
                     .with_gas_limit(gas_limit);
 
                 let res = provider.send_transaction(tx).await.unwrap();
@@ -142,6 +144,7 @@ where
 
             println!("running setup: {:?}", tx_req.name);
             let handle = tokio::task::spawn(async move {
+                let chain_id = provider.get_chain_id().await.expect("failed to get chain id");
                 let gas_price = provider.get_gas_price().await.unwrap();
                 let gas_limit = provider
                     .estimate_gas(&tx_req.tx)
@@ -150,6 +153,7 @@ where
                 let tx = tx_req
                     .tx
                     .with_gas_price(gas_price)
+                    .with_chain_id(chain_id)
                     .with_gas_limit(gas_limit);
                 let res = provider.send_transaction(tx).await.unwrap();
                 let receipt = res.get_receipt().await.unwrap();

--- a/src/test_scenario.rs
+++ b/src/test_scenario.rs
@@ -61,9 +61,14 @@ where
         // only_with_names: Option<&[impl AsRef<str>]>,
     ) -> Result<(), ContenderError> {
         let pub_provider = ProviderBuilder::new().on_http(self.rpc_url.clone());
-        let gas_price = pub_provider.get_gas_price().await.map_err(|e| {
-            ContenderError::SetupError("failed to get gas price", Some(e.to_string()))
-        })?;
+        let gas_price = pub_provider
+            .get_gas_price()
+            .await
+            .map_err(|e| ContenderError::with_err(e, "failed to get gas price"))?;
+        let chain_id = pub_provider
+            .get_chain_id()
+            .await
+            .map_err(|e| ContenderError::with_err(e, "failed to get chain id"))?;
 
         // we do everything in the callback so no need to actually capture the returned txs
         self.load_txs(PlanType::Create(|tx_req| {
@@ -87,7 +92,6 @@ where
 
             println!("deploying contract: {:?}", tx_req.name);
             let handle = tokio::task::spawn(async move {
-                let chain_id = provider.get_chain_id().await.expect("failed to get chain id");
                 // estimate gas limit
                 let gas_limit = provider
                     .estimate_gas(&tx_req.tx)
@@ -144,7 +148,10 @@ where
 
             println!("running setup: {:?}", tx_req.name);
             let handle = tokio::task::spawn(async move {
-                let chain_id = provider.get_chain_id().await.expect("failed to get chain id");
+                let chain_id = provider
+                    .get_chain_id()
+                    .await
+                    .expect("failed to get chain id");
                 let gas_price = provider.get_gas_price().await.unwrap();
                 let gas_limit = provider
                     .estimate_gas(&tx_req.tx)


### PR DESCRIPTION
additions to #24 
- **only query chain_id once at beginning of methods, and cleanup some errors**
