### PR TITLE
feature-flag async tracing (access via tokio-console) w/ new flag

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -50,4 +50,4 @@ tempfile = "3.15.0"
 
 [features]
 default = []
-trace-async = ["dep:console-subscriber"]
+async-tracing = ["dep:console-subscriber"]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -246,7 +246,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 fn init_tracing() {
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")); // fallback if RUST_LOG is unset
-    #[cfg(feature = "trace-async")]
+    #[cfg(feature = "async-tracing")]
     {
         use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, Layer};
         let tokio_layer = console_subscriber::ConsoleLayer::builder()
@@ -263,7 +263,7 @@ fn init_tracing() {
             .init();
     }
 
-    #[cfg(not(feature = "trace-async"))]
+    #[cfg(not(feature = "async-tracing"))]
     {
         tracing_subscriber::fmt()
             .with_env_filter(filter)


### PR DESCRIPTION
## Motivation

prevent error from compiling w/ default settings (`cargo install` doesn't work w/o a special flag)

## Solution

add a feature flag to use the crate causing trouble: `--features async-tracing`; disabled by default bc it's only useful for devs

if you're compiling locally (i.e. in the project root) you won't need to provide the "special flag" because it's specified [in the workspace manifest](https://github.com/flashbots/contender/blob/main/.cargo/config.toml#L2) but if you want the feature via `cargo install` you need to pass `--cfg tokio_unstable` to cargo via RUSTFLAGS:

```sh
RUSTFLAGS="--cfg tokio_unstable" cargo install \
--git https://github.com/flashbots/contender \
--locked --force --features async-tracing
```

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes