### PR TITLE
chore: set version v0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2101,7 +2101,7 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "contender_bundle_provider"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "alloy",
  "serde",
@@ -2110,7 +2110,7 @@ dependencies = [
 
 [[package]]
 name = "contender_cli"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "alloy",
  "async-trait",
@@ -2141,7 +2141,7 @@ dependencies = [
 
 [[package]]
 name = "contender_core"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "alloy",
  "async-trait",
@@ -2163,7 +2163,7 @@ dependencies = [
 
 [[package]]
 name = "contender_engine_provider"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "alloy",
  "alloy-json-rpc",
@@ -2187,7 +2187,7 @@ dependencies = [
 
 [[package]]
 name = "contender_report"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "alloy",
  "chrono",
@@ -2205,7 +2205,7 @@ dependencies = [
 
 [[package]]
 name = "contender_sqlite"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "alloy",
  "contender_core",
@@ -2218,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "contender_testfile"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "alloy",
  "contender_core",

--- a/crates/bundle_provider/CHANGELOG.md
+++ b/crates/bundle_provider/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.2](https://github.com/flashbots/contender/releases/tag/contender_bundle_provider-v0.5.2) - 2025-05-14
+## [0.5.3](https://github.com/flashbots/contender/releases/tag/contender_bundle_provider-v0.5.3) - 2025-05-14
 
 ### Other
 

--- a/crates/bundle_provider/Cargo.toml
+++ b/crates/bundle_provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contender_bundle_provider"
-version = "0.5.2"
+version = "0.5.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.2](https://github.com/flashbots/contender/releases/tag/contender_cli-v0.5.2) - 2025-05-14
+## [0.5.3](https://github.com/flashbots/contender/releases/tag/contender_cli-v0.5.3) - 2025-05-14
 
 ### Added
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contender_cli"
-version = "0.5.2"
+version = "0.5.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.2](https://github.com/flashbots/contender/releases/tag/contender_core-v0.5.2) - 2025-05-14
+## [0.5.3](https://github.com/flashbots/contender/releases/tag/contender_core-v0.5.3) - 2025-05-14
 
 ### Added
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contender_core"
-version = "0.5.2"
+version = "0.5.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/engine_provider/CHANGELOG.md
+++ b/crates/engine_provider/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.2](https://github.com/flashbots/contender/releases/tag/contender_engine_provider-v0.5.2) - 2025-05-14
+## [0.5.3](https://github.com/flashbots/contender/releases/tag/contender_engine_provider-v0.5.3) - 2025-05-14
 
 ### Other
 

--- a/crates/engine_provider/Cargo.toml
+++ b/crates/engine_provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contender_engine_provider"
-version = "0.5.2"
+version = "0.5.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/report/CHANGELOG.md
+++ b/crates/report/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.2](https://github.com/flashbots/contender/releases/tag/contender_report-v0.5.2) - 2025-05-14
+## [0.5.3](https://github.com/flashbots/contender/releases/tag/contender_report-v0.5.3) - 2025-05-14
 
 ### Added
 

--- a/crates/report/Cargo.toml
+++ b/crates/report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contender_report"
-version = "0.5.2"
+version = "0.5.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/sqlite_db/CHANGELOG.md
+++ b/crates/sqlite_db/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.2](https://github.com/flashbots/contender/releases/tag/contender_sqlite-v0.5.2) - 2025-05-14
+## [0.5.3](https://github.com/flashbots/contender/releases/tag/contender_sqlite-v0.5.3) - 2025-05-14
 
 ### Other
 

--- a/crates/sqlite_db/Cargo.toml
+++ b/crates/sqlite_db/Cargo.toml
@@ -7,7 +7,7 @@ name = "contender_sqlite"
 description = "SQLite database for contender"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.5.2"
+version = "0.5.3"
 
 [dependencies]
 alloy = { workspace = true }

--- a/crates/testfile/CHANGELOG.md
+++ b/crates/testfile/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.2](https://github.com/flashbots/contender/releases/tag/contender_testfile-v0.5.2) - 2025-05-14
+## [0.5.3](https://github.com/flashbots/contender/releases/tag/contender_testfile-v0.5.3) - 2025-05-14
 
 ### Fixed
 

--- a/crates/testfile/Cargo.toml
+++ b/crates/testfile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contender_testfile"
-version = "0.5.2"
+version = "0.5.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## new features

- reads `CONTENDER_PRIVATE_KEY` directly so `-p` doesn't have to be specified in sensitive environments