### PR TITLE
fix(anvil): harden forked anvil initialization to prevent hanging

### DIFF
--- a/crates/core/src/test_scenario.rs
+++ b/crates/core/src/test_scenario.rs
@@ -323,14 +323,11 @@ where
     }
 
     // Polls anvil to ensure its initialized and ready to accept RPC requests
-    async fn wait_for_anvil_ready(
-        endpoint_url: &str,
-        timeout: Duration,
-    ) -> Result<()> {
+    async fn wait_for_anvil_ready(endpoint_url: &str, timeout: Duration) -> Result<()> {
         let start = std::time::Instant::now();
         let url = Url::parse(endpoint_url)
             .map_err(|e| ContenderError::with_err(e, "failed to parse Anvil endpoint URL"))?;
-        
+
         loop {
             if start.elapsed() > timeout {
                 return Err(ContenderError::SetupError(
@@ -338,16 +335,13 @@ where
                     Some(format!("Waited {} seconds", timeout.as_secs())),
                 ));
             }
-            
+
             // Try a simple RPC call to check if Anvil is responsive
             let provider = ProviderBuilder::new()
                 .network::<AnyNetwork>()
                 .connect_http(url.clone());
-            
-            match tokio::time::timeout(
-                Duration::from_secs(2),
-                provider.get_block_number()
-            ).await {
+
+            match tokio::time::timeout(Duration::from_secs(2), provider.get_block_number()).await {
                 Ok(Ok(_block_num)) => {
                     info!("anvil ready at {}", endpoint_url);
                     return Ok(());
@@ -359,11 +353,10 @@ where
                     info!("anvil health check timed out, retrying...");
                 }
             }
-            
+
             tokio::time::sleep(Duration::from_millis(500)).await;
         }
     }
-
 
     pub async fn estimate_setup_cost(&self) -> Result<U256> {
         info!(


### PR DESCRIPTION
## Motivation

When running contender against an http (instead of ws) rpc url, the initial simulation step would intermittently hang indefinitely. Anvil in fork mode relies on syncing blocks from the remote chain to trigger local block production. When the remote rpc is http, anvil cannot use `eth_subscribe` (only supported on ws) to receive real-time block updates. Anvil's fallback http polling mechanism appears buggy/incomplete, resulting in Anvil never mining blocks for local transactions. This causes the `.watch()` calls (which wait for tx confirmations) to hang forever.

## Solution

Makes the following changes to improve reliability of the anvil simulation, maintaining compatibility with http and ws rpc endpoints:

* add `block_time(1)`: forces anvil to mine blocks locally every 1 second (the minimum interval Anvil supports), independent of remote chain sync. This ensures local transactions get mined predictably regardless of rpc transport type.
* add `timeout(60000)`: sets a 60s timeout on the anvil fork operation to prevent indefinite hangs during the initial remote state fetch
* add `wait_for_anvil_ready()`: polls anvil's rpc endpoint with a 30-second timeout to ensure Anvil is ready to accept requests before sending transactions. This prevents race conditions where simulation RPC calls are made before Anvil has finished initializing.