### PR TITLE
fix(campaign): consistent seeds for builtin scenarios

### DIFF
--- a/crates/cli/src/commands/common.rs
+++ b/crates/cli/src/commands/common.rs
@@ -203,11 +203,11 @@ Required if --auth-rpc-url is set.",
         value_enum,
         default_value_t = EngineMessageVersion::V4
     )]
-    message_version: EngineMessageVersion,
+    pub message_version: EngineMessageVersion,
 }
 
 #[derive(Copy, Debug, Clone, clap::ValueEnum)]
-enum EngineMessageVersion {
+pub enum EngineMessageVersion {
     V1,
     V2,
     V3,


### PR DESCRIPTION
## Description

- Use base_seed for builtin scenarios in both setup and spam phases to ensure agent addresses match (fixes token transfer failures)
- Propagate errors from stage execution instead of silently dropping them
- Set redeploy=false in spam phase since setup already handles it

## Motivation

campaign runs weren't performing the same way as regular spam runs

## Benchmarking
- Before: 88 MGas/s max, 28 MGas/s mean
- After: 139 MGas/s max, 29 MGas/s mean

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [x] Ran `cargo +nightly clippy --workspace --lib --examples --tests --benches --all-features --locked --fix`
- [x] Ran `cargo fmt --all`
- [x] Note breaking changes in PR description, if applicable
- [ ] update changelogs
    - [ ] Update `CHANGELOG.md` in each affected crate
    - [ ] add a high-level description in the [root changelog](../CHANGELOG.md)
