### PR TITLE
differentiate initialized Contender from uninitialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- refactored `Contender` orchestrator to a typestate-based lifecycle — `Contender<Uninitialized>` vs `Contender<Initialized>` — eliminating all runtime lifecycle checks and enforcing correct usage at compile time ([#507](https://github.com/flashbots/contender/pull/507))
 - custom spam callbacks can now wrap a `LogCallback` via `LogCallback::with_callback` to inherit the tx-caching and FCU behavior that `contender report` depends on, removing the boilerplate that previously caused custom callbacks to silently break reporting ([#326](https://github.com/flashbots/contender/issues/326))
 - added contender server + some supporting (and internally-breaking) changes ([#494](https://github.com/flashbots/contender/pull/494/))
 

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- updated session management to support typestate-based `Contender` lifecycle ([#507](https://github.com/flashbots/contender/pull/507))
+  - `ContenderSession.contender` now wraps a `SessionContender` enum (`Uninit` / `Init`)
+  - `take_contender` / `put_contender` replaced by typed `take_uninitialized` / `take_initialized` / `put_initialized`
 - contender API ([#494](https://github.com/flashbots/contender/pull/494/changes))
   - new `contender server` command; run contender instances via JSON-RPC
   - exposes CLI as a reusable library

--- a/crates/cli/src/server/rpc_server/server.rs
+++ b/crates/cli/src/server/rpc_server/server.rs
@@ -103,29 +103,29 @@ impl ContenderRpcServer for ContenderServer {
             contender_core::CURRENT_SESSION_ID.scope(
                 session_id,
                 async move {
-                    // Take contender instance so we can initialize without holding the lock.
+                    // Take uninitialized contender so we can initialize without holding the lock.
                     let contender = {
                         let mut lock = sessions.write().await;
-                        lock.take_contender(session_id)
+                        lock.take_uninitialized(session_id)
                     };
 
-                    let Some(mut contender) = contender else {
+                    let Some(contender) = contender else {
                         return;
                     };
 
-                    let result = contender.initialize().await;
-
-                    // Put contender back and update status.
-                    let mut lock = sessions.write().await;
-                    lock.put_contender(session_id, contender);
-                    if let Some(session) = lock.get_session_mut(session_id) {
-                        match result {
-                            Ok(()) => {
+                    match contender.initialize().await {
+                        Ok(initialized) => {
+                            let mut lock = sessions.write().await;
+                            lock.put_initialized(session_id, initialized);
+                            if let Some(session) = lock.get_session_mut(session_id) {
                                 session.info.status = SessionStatus::Ready;
                                 info!("Session {} initialized successfully", session_id);
                             }
-                            Err(e) => {
-                                let msg = e.to_string();
+                        }
+                        Err(e) => {
+                            let msg = e.to_string();
+                            let mut lock = sessions.write().await;
+                            if let Some(session) = lock.get_session_mut(session_id) {
                                 session.info.status = SessionStatus::Failed(msg.clone());
                                 tracing::error!(
                                     "Session {} initialization failed: {}",
@@ -213,7 +213,7 @@ impl ContenderRpcServer for ContenderServer {
         let save_receipts = params.save_receipts.unwrap_or(false);
         drop(sessions);
 
-        // Take contender instance so we can spam without holding the `sessions` lock.
+        // Take initialized contender instance so we can spam without holding the `sessions` lock.
         let spam_cancel = CancellationToken::new();
         let contender = {
             let mut lock = self.sessions.write().await;
@@ -221,7 +221,7 @@ impl ContenderRpcServer for ContenderServer {
                 session.info.status = SessionStatus::Spamming(params.clone());
                 session.spam_cancel = Some(spam_cancel.clone());
             }
-            lock.take_contender(session_id)
+            lock.take_initialized(session_id)
         };
 
         let Some(contender) = contender else {
@@ -339,7 +339,8 @@ impl ContenderRpcServer for ContenderServer {
                         };
 
                         // Clear pending tx cache and sync nonces before returning the contender.
-                        if let Some(scenario) = contender.state.scenario_mut() {
+                        {
+                            let scenario = contender.scenario_mut();
                             for handle in scenario.msg_handles.values() {
                                 if let Err(e) = handle.clear_cache().await {
                                     warn!("Failed to clear pending tx cache: {e}");
@@ -352,7 +353,7 @@ impl ContenderRpcServer for ContenderServer {
 
                         // Put contender back and log outcome.
                         let mut lock = sessions.write().await;
-                        lock.put_contender(session_id, contender);
+                        lock.put_initialized(session_id, contender);
                         if let Some(session) = lock.get_session_mut(session_id) {
                             session.spam_cancel = None;
                         }

--- a/crates/cli/src/server/sessions.rs
+++ b/crates/cli/src/server/sessions.rs
@@ -8,7 +8,7 @@ use contender_core::{
     alloy::{primitives::U256, signers::local::PrivateKeySigner},
     generator::{types::AnyProvider, RandSeed},
     test_scenario::Url,
-    Contender,
+    Contender, Initialized, Uninitialized,
 };
 use contender_sqlite::SqliteDb;
 use contender_testfile::TestConfig;
@@ -50,12 +50,21 @@ impl std::fmt::Display for SessionStatus {
     }
 }
 
+type InitContender =
+    Contender<SqliteDb, RandSeed, TestConfig, Initialized<SqliteDb, RandSeed, TestConfig>>;
+
+/// Wraps the two possible lifecycle states of a session's `Contender`.
+pub enum SessionContender {
+    Uninit(Contender<SqliteDb, RandSeed, TestConfig, Uninitialized>),
+    Init(InitContender),
+}
+
 pub struct ContenderSession {
     /// Metadata about this session (id, name, rpc_url, status).
     pub info: ContenderSessionInfo,
     /// The contender instance for this session. `None` while it is taken out for
     /// initialization or spamming (to avoid holding the lock during long operations).
-    pub contender: Option<Contender<SqliteDb, RandSeed, TestConfig>>,
+    pub contender: Option<SessionContender>,
     /// Broadcast channel for per-session log lines. The tracing layer sends formatted
     /// events here; WS and SSE subscribers receive from it.
     pub log_channel: broadcast::Sender<String>,
@@ -102,7 +111,7 @@ impl ContenderSession {
         let (log_channel, _) = broadcast::channel(4096);
         Ok(Self {
             info,
-            contender: Some(contender),
+            contender: Some(SessionContender::Uninit(contender)),
             log_channel,
             cancel: CancellationToken::new(),
             spam_cancel: None,
@@ -127,7 +136,7 @@ impl ContenderSessionInfo {
         &self,
         testconfig: TestConfig,
         options: SessionOptions,
-    ) -> Result<Contender<SqliteDb, RandSeed, TestConfig>, ContenderRpcError> {
+    ) -> Result<Contender<SqliteDb, RandSeed, TestConfig, Uninitialized>, ContenderRpcError> {
         // using in-memory SQLite for now; will switch to file-based if we need persistence across server restarts
         let db = contender_sqlite::SqliteDb::new_memory();
         let seeder = contender_core::generator::RandSeed::seed_from_bytes(&self.id.to_be_bytes());
@@ -242,31 +251,46 @@ impl ContenderSessionCache {
         self.sessions.iter_mut().find(|s| s.info.id == id)
     }
 
-    /// Take the Contender out of a session so it can be used outside the lock.
-    pub fn take_contender(
+    /// Take an uninitialized Contender out of a session so it can be initialized outside the lock.
+    pub fn take_uninitialized(
         &mut self,
         id: SessionId,
-    ) -> Option<Contender<SqliteDb, RandSeed, TestConfig>> {
-        self.get_session_mut(id).and_then(|s| s.contender.take())
+    ) -> Option<Contender<SqliteDb, RandSeed, TestConfig, Uninitialized>> {
+        let session = self.get_session_mut(id)?;
+        match session.contender.take() {
+            Some(SessionContender::Uninit(c)) => Some(c),
+            other => {
+                // put it back if it was the wrong variant
+                session.contender = other;
+                None
+            }
+        }
     }
 
-    /// Put the Contender back into a session after initialization or spamming.
+    /// Take an initialized Contender out of a session so it can be used outside the lock.
+    pub fn take_initialized(&mut self, id: SessionId) -> Option<InitContender> {
+        let session = self.get_session_mut(id)?;
+        match session.contender.take() {
+            Some(SessionContender::Init(c)) => Some(c),
+            other => {
+                // put it back if it was the wrong variant
+                session.contender = other;
+                None
+            }
+        }
+    }
+
+    /// Put an initialized Contender back into a session.
     /// Also caches funding-related data so `fund_accounts` can work while the
     /// contender is taken for spamming.
-    pub fn put_contender(
-        &mut self,
-        id: SessionId,
-        contender: Contender<SqliteDb, RandSeed, TestConfig>,
-    ) {
+    pub fn put_initialized(&mut self, id: SessionId, contender: InitContender) {
         if let Some(session) = self.get_session_mut(id) {
-            // Cache funding data from the initialized scenario.
-            if let Some(scenario) = contender.state.scenario() {
-                session.funder = contender.funder().cloned();
-                session.agent_store = Some(scenario.agent_store.clone());
-                session.rpc_client = Some(scenario.rpc_client.clone());
-                session.min_balance = Some(contender.min_balance());
-            }
-            session.contender = Some(contender);
+            let scenario = contender.scenario();
+            session.funder = contender.funder().cloned();
+            session.agent_store = Some(scenario.agent_store.clone());
+            session.rpc_client = Some(scenario.rpc_client.clone());
+            session.min_balance = Some(contender.min_balance());
+            session.contender = Some(SessionContender::Init(contender));
         }
     }
 

--- a/crates/cli/src/server/static/openrpc.json
+++ b/crates/cli/src/server/static/openrpc.json
@@ -18,7 +18,7 @@
       "BundleCallDefinition": {"file":"crates/core/src/generator/function_def.rs","line":53},
       "BundleTypeCli": {"file":"crates/cli/src/commands/common.rs","line":426},
       "CompiledContract": {"file":"crates/core/src/generator/create_def.rs","line":8},
-      "ContenderSessionInfo": {"file":"crates/cli/src/server/sessions.rs","line":118},
+      "ContenderSessionInfo": {"file":"crates/cli/src/server/sessions.rs","line":127},
       "CreateDefinition": {"file":"crates/core/src/generator/create_def.rs","line":65},
       "CustomContractCliArgs": {"file":"crates/cli/src/default_scenarios/custom_contract.rs","line":17},
       "EngineMessageVersion": {"file":"crates/cli/src/commands/common.rs","line":268},

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- refactored `Contender` to use a typestate-based lifecycle instead of the runtime `ContenderState` enum ([#507](https://github.com/flashbots/contender/pull/507))
+  - `Contender<D, S, P, State>` is now generic over a `State` parameter (defaults to `Uninitialized`)
+  - `initialize(self)` consumes the uninitialized contender and returns `Contender<..., Initialized<...>>`
+  - `spam`, `fund_accounts`, `scenario`, and `scenario_mut` are only callable on `Contender<..., Initialized<...>>`
+  - added `initialize_and_spam` convenience helper on `Contender<..., Uninitialized>`
+  - added `LifecyclePhase` enum and `PhaseMarker` trait for read-only phase introspection
+  - new re-exports: `Initialized`, `Uninitialized`, `LifecyclePhase`, `PhaseMarker`
 - added `CombinedCallback<A, B>` and `LogCallback::with_callback` builder so custom spam callbacks can inherit `LogCallback`'s tx-caching (and optional FCU) behavior without duplicating its internals ([#326](https://github.com/flashbots/contender/issues/326))
 
 *from [#494](https://github.com/flashbots/contender/pull/494/changes)*:
@@ -27,6 +34,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `TestScenario::sync_nonces` now checks for `self.should_sync_nonces` so it may be blindly called
 
 ### Breaking changes
+
+*from [#507](https://github.com/flashbots/contender/pull/507)*:
+
+- `contender_core::orchestrator::ContenderState` has been removed.
+  - Replace `contender.state.scenario()` with `contender.scenario()` (infallible on `Initialized`).
+  - Replace `contender.state.scenario_mut()` with `contender.scenario_mut()`.
+  - Replace `contender.state.is_initialized()` checks with compile-time enforcement.
+- `Contender::new` now returns `Contender<D, S, P, Uninitialized>`.
+- `Contender::initialize` now consumes `self` and returns `Result<Contender<D, S, P, Initialized<D, S, P>>>`.
+  - Callers must bind the returned value: `let contender = contender.initialize().await?;`
+- `Contender::spam` is no longer available on `Contender<..., Uninitialized>` — call `initialize` first.
+  - The implicit auto-initialization inside `spam` has been removed.
 
 *from [#494](https://github.com/flashbots/contender/pull/494/changes)*:
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -16,7 +16,9 @@ pub type Result<T> = std::result::Result<T, error::Error>;
 
 pub use alloy;
 pub use contender_bundle_provider::bundle::BundleType;
-pub use orchestrator::{Contender, ContenderCtx, RunOpts};
+pub use orchestrator::{
+    Contender, ContenderCtx, Initialized, LifecyclePhase, PhaseMarker, RunOpts, Uninitialized,
+};
 pub use tokio::task as tokio_task;
 pub use tokio_util::sync::CancellationToken;
 

--- a/crates/core/src/orchestrator.rs
+++ b/crates/core/src/orchestrator.rs
@@ -6,7 +6,6 @@ use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
 use crate::{
     agent_controller::AgentClass,
     db::{DbOps, MockDb, SpamDuration, SpamRunRequest},
-    error::RuntimeErrorKind,
     generator::{
         agent_pools::AgentSpec,
         seeder::{rand_seed::SeedGenerator, Seeder},
@@ -238,7 +237,7 @@ where
         .await
     }
 
-    pub fn create_contender(self) -> Contender<D, S, P> {
+    pub fn create_contender(self) -> Contender<D, S, P, Uninitialized> {
         Contender::new(self)
     }
 }
@@ -431,53 +430,108 @@ impl RunOpts {
     }
 }
 
+// ── Typestate markers ──────────────────────────────────────────────────
+
+/// Lifecycle phase indicator (read-only introspection).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LifecyclePhase {
+    Uninitialized,
+    Initialized,
+}
+
+/// Trait implemented by state-marker types for compile-time phase introspection.
+pub trait PhaseMarker {
+    const PHASE: LifecyclePhase;
+}
+
+/// Marker: the `Contender` has not yet been initialized.
+pub struct Uninitialized;
+
+impl PhaseMarker for Uninitialized {
+    const PHASE: LifecyclePhase = LifecyclePhase::Uninitialized;
+}
+
+/// Marker: the `Contender` has been initialized and holds a valid scenario.
+pub struct Initialized<D, S, P>
+where
+    D: DbOps + Clone + Send + Sync + 'static,
+    S: SeedGenerator + Send + Sync + Clone,
+    P: PlanConfig<String> + Templater<String> + Send + Sync + Clone,
+{
+    scenario: Box<TestScenario<D, S, P>>,
+}
+
+impl<D, S, P> PhaseMarker for Initialized<D, S, P>
+where
+    D: DbOps + Clone + Send + Sync + 'static,
+    S: SeedGenerator + Send + Sync + Clone,
+    P: PlanConfig<String> + Templater<String> + Send + Sync + Clone,
+{
+    const PHASE: LifecyclePhase = LifecyclePhase::Initialized;
+}
+
+// ── Contender struct ──────────────────────────────────────────────────
+
 /// Orchestrator that plugs a built scenario into any `Spammer`.
-pub struct Contender<D, S, P>
+///
+/// Generic over a `State` type parameter that determines which methods are
+/// available.  `Contender<D, S, P, Uninitialized>` can only be initialized,
+/// while `Contender<D, S, P, Initialized<D, S, P>>` provides `spam`,
+/// `fund_accounts`, and direct scenario access.
+pub struct Contender<D, S, P, State = Uninitialized>
 where
     D: DbOps + Clone + Send + Sync + 'static,
     S: SeedGenerator + Send + Sync + Clone,
     P: PlanConfig<String> + Templater<String> + Send + Sync + Clone,
 {
     ctx: ContenderCtx<D, S, P>,
-    pub state: ContenderState<D, S, P>,
+    state: State,
 }
 
-pub enum ContenderState<D, S, P>
+// ── Methods available on ANY Contender, regardless of state ───────────
+
+impl<D, S, P, State> Contender<D, S, P, State>
 where
     D: DbOps + Clone + Send + Sync + 'static,
     S: SeedGenerator + Send + Sync + Clone,
     P: PlanConfig<String> + Templater<String> + Send + Sync + Clone,
 {
-    Uninitialized,
-    Initialized(Box<TestScenario<D, S, P>>),
+    /// Returns the current lifecycle phase (read-only introspection).
+    pub fn phase(&self) -> LifecyclePhase
+    where
+        State: PhaseMarker,
+    {
+        State::PHASE
+    }
+
+    /// Materialize a fresh `TestScenario` using the context which was used to create this `Contender` instance.
+    pub async fn build_scenario(&self) -> Result<TestScenario<D, S, P>> {
+        self.ctx.build_scenario().await
+    }
+
+    /// Produce a web3 provider connected to the current instance's RPC URL.
+    pub fn provider(&self) -> AnyProvider {
+        DynProvider::new(
+            alloy::providers::ProviderBuilder::new()
+                .network::<AnyNetwork>()
+                .connect_http(self.ctx.rpc_url.clone()),
+        )
+    }
+
+    /// Returns a reference to the first user signer (the funder account).
+    pub fn funder(&self) -> Option<&PrivateKeySigner> {
+        self.ctx.user_signers.first()
+    }
+
+    /// Returns the configured minimum balance (funding amount) for agent accounts.
+    pub fn min_balance(&self) -> U256 {
+        self.ctx.funding
+    }
 }
 
-impl<D, S, P> ContenderState<D, S, P>
-where
-    D: DbOps + Clone + Send + Sync + 'static,
-    S: SeedGenerator + Send + Sync + Clone,
-    P: PlanConfig<String> + Templater<String> + Send + Sync + Clone,
-{
-    pub fn scenario(&self) -> Option<&TestScenario<D, S, P>> {
-        match self {
-            ContenderState::Uninitialized => None,
-            ContenderState::Initialized(scenario) => Some(scenario),
-        }
-    }
+// ── Uninitialized-only methods ────────────────────────────────────────
 
-    pub fn scenario_mut(&mut self) -> Option<&mut TestScenario<D, S, P>> {
-        match self {
-            ContenderState::Uninitialized => None,
-            ContenderState::Initialized(scenario) => Some(scenario),
-        }
-    }
-
-    pub fn is_initialized(&self) -> bool {
-        matches!(self, ContenderState::Initialized(_))
-    }
-}
-
-impl<D, S, P> Contender<D, S, P>
+impl<D, S, P> Contender<D, S, P, Uninitialized>
 where
     D: DbOps + Clone + Send + Sync + 'static,
     S: SeedGenerator + Send + Sync + Clone,
@@ -502,19 +556,20 @@ where
     /// let spammer = TimedSpammer::new(std::time::Duration::from_secs(1));
     ///
     /// // Run the spammer (async context required)
-    /// // contender.spam(spammer, NilCallback.into(), RunOpts::default()).await.unwrap();
+    /// // let contender = contender.initialize().await.unwrap();
+    /// // contender.spam(spammer, NilCallback.into(), RunOpts::default(), None).await.unwrap();
     /// ```
     pub fn new(ctx: ContenderCtx<D, S, P>) -> Self {
         Self {
             ctx,
-            state: ContenderState::Uninitialized,
+            state: Uninitialized,
         }
     }
 
     /// Funds agent accounts, then runs contract deployments and setup transactions.
     ///
-    /// Run this before calling `spam`.
-    pub async fn initialize(&mut self) -> Result<()> {
+    /// Consumes the uninitialized `Contender` and returns an initialized one.
+    pub async fn initialize(self) -> Result<Contender<D, S, P, Initialized<D, S, P>>> {
         let mut scenario = self.ctx.build_scenario().await?;
         for agent in scenario.agent_store.all_agents() {
             agent
@@ -528,8 +583,52 @@ where
         }
         scenario.deploy_contracts().await?;
         scenario.run_setup().await?;
-        self.state = ContenderState::Initialized(scenario.into());
-        Ok(())
+        Ok(Contender {
+            ctx: self.ctx,
+            state: Initialized {
+                scenario: scenario.into(),
+            },
+        })
+    }
+
+    /// Convenience helper: initializes and then runs spam in one call.
+    ///
+    /// Returns the initialized `Contender` so it can be reused.
+    pub async fn initialize_and_spam<F, SP>(
+        self,
+        spammer: SP,
+        callback: Arc<F>,
+        opts: RunOpts,
+        cancel_token: Option<CancellationToken>,
+    ) -> Result<Contender<D, S, P, Initialized<D, S, P>>>
+    where
+        F: OnTxSent + OnBatchSent + Send + Sync + 'static,
+        SP: Spammer<F, D, S, P>,
+    {
+        let mut contender = self.initialize().await?;
+        contender
+            .spam(spammer, callback, opts, cancel_token)
+            .await?;
+        Ok(contender)
+    }
+}
+
+// ── Initialized-only methods ──────────────────────────────────────────
+
+impl<D, S, P> Contender<D, S, P, Initialized<D, S, P>>
+where
+    D: DbOps + Clone + Send + Sync + 'static,
+    S: SeedGenerator + Send + Sync + Clone,
+    P: PlanConfig<String> + Templater<String> + Send + Sync + Clone,
+{
+    /// Returns a reference to the test scenario.
+    pub fn scenario(&self) -> &TestScenario<D, S, P> {
+        &self.state.scenario
+    }
+
+    /// Returns a mutable reference to the test scenario.
+    pub fn scenario_mut(&mut self) -> &mut TestScenario<D, S, P> {
+        &mut self.state.scenario
     }
 
     /// Run the spammer.
@@ -580,8 +679,9 @@ where
     /// // create a cancellation token that can be used to stop the spam run from outside the `Contender` (optional)
     /// let cancel_token = tokio_util::sync::CancellationToken::new();
     ///
-    /// // run spammer
-    /// contender.spam(spammer, callback.into(), opts, Some(cancel_token.clone())).await.unwrap();
+    /// // initialize, then run spammer
+    /// // let contender = contender.initialize().await.unwrap();
+    /// // contender.spam(spammer, callback.into(), opts, Some(cancel_token.clone())).await.unwrap();
     /// ```
     pub async fn spam<F, SP>(
         &mut self,
@@ -594,14 +694,7 @@ where
         F: OnTxSent + OnBatchSent + Send + Sync + 'static,
         SP: Spammer<F, D, S, P>,
     {
-        // call self.initialize if it hasn't yet been called manually
-        if !self.state.is_initialized() {
-            self.initialize().await?;
-        }
-
-        // get mutable ref to scenario so nonce state persists across calls
-        let scenario = self.state.scenario_mut()
-            .expect("if initialize() fails, it will throw an error before this point, so scenario should always be available here");
+        let scenario = &mut *self.state.scenario;
 
         // reset cancel token & restart flush loops if this isn't the first run
         scenario.prepare_for_run().await?;
@@ -677,35 +770,8 @@ where
         result
     }
 
-    /// Materialize a fresh `TestScenario` using the context which was used to create this `Contender` instance.
-    pub async fn build_scenario(&self) -> Result<TestScenario<D, S, P>> {
-        self.ctx.build_scenario().await
-    }
-
-    /// Produce a web3 provider connected to the current instance's RPC URL.
-    pub fn provider(&self) -> AnyProvider {
-        DynProvider::new(
-            alloy::providers::ProviderBuilder::new()
-                .network::<AnyNetwork>()
-                .connect_http(self.ctx.rpc_url.clone()),
-        )
-    }
-
-    /// Returns a reference to the first user signer (the funder account).
-    pub fn funder(&self) -> Option<&PrivateKeySigner> {
-        self.ctx.user_signers.first()
-    }
-
-    /// Returns the configured minimum balance (funding amount) for agent accounts.
-    pub fn min_balance(&self) -> U256 {
-        self.ctx.funding
-    }
-
     pub async fn fund_accounts(&self, agent_class: AgentClass, amount: U256) -> Result<()> {
-        let scenario = self
-            .state
-            .scenario()
-            .ok_or_else(|| RuntimeErrorKind::ScenarioNotFound)?;
+        let scenario = &*self.state.scenario;
 
         let funder = &self.ctx.user_signers[0];
         let agent = scenario.agent_store.get_class(&agent_class);

--- a/crates/testfile/src/lib.rs
+++ b/crates/testfile/src/lib.rs
@@ -606,11 +606,12 @@ mod more_tests {
         let db = MockDb;
         let seeder = RandSeed::new();
         let ctx = ContenderCtx::builder(config, db, seeder, anvil.endpoint_url()).build();
-        let mut contender = Contender::new(ctx);
+        let contender = Contender::new(ctx);
 
         let spammer = TimedSpammer::new(Duration::from_secs(1));
         let callback = NilCallback;
         let opts = RunOpts::new().txs_per_period(100).periods(3);
+        let mut contender = contender.initialize().await?;
         contender.spam(spammer, callback.into(), opts, None).await?;
 
         Ok(())


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/flashbots/contender/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

resolves https://github.com/flashbots/contender/issues/505

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- add `PhaseMarker` to differentiate initialized/uninitialized instances of `Contender`
  - add type bound `State` to `Contender` to differentiate at compile-time
- separate functions from `Contender` by initialization requirements

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Ran `cargo +nightly clippy --workspace --lib --examples --tests --benches --all-features --locked --fix`
- [x] Ran `cargo fmt --all`
- [x] Note breaking changes in PR description, if applicable
- [x] update changelogs
    - [x] Update `CHANGELOG.md` in each affected crate
    - [x] add a high-level description in the [root changelog](../CHANGELOG.md)
