### PR TITLE
improve campaign/spam logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- improve campaign/spam logs (particularly when `--report` is passed) ([#508](https://github.com/flashbots/contender/pull/508))
 - refactored `Contender` orchestrator to a typestate-based lifecycle — `Contender<Uninitialized>` vs `Contender<Initialized>` — eliminating all runtime lifecycle checks and enforcing correct usage at compile time ([#507](https://github.com/flashbots/contender/pull/507))
 - custom spam callbacks can now wrap a `LogCallback` via `LogCallback::with_callback` to inherit the tx-caching and FCU behavior that `contender report` depends on, removing the boilerplate that previously caused custom callbacks to silently break reporting ([#326](https://github.com/flashbots/contender/issues/326))
 - added contender server + some supporting (and internally-breaking) changes ([#494](https://github.com/flashbots/contender/pull/494/))

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- updated session management to support typestate-based `Contender` lifecycle ([#507](https://github.com/flashbots/contender/pull/507))
+- improve campaign/spam logs (particularly when `--report` is passed) ([#508](https://github.com/flashbots/contender/pull/508/changes))
+- updated session management to support typestate-based `Contender` lifecycle ([#507](https://github.com/flashbots/contender/pull/507/changes))
   - `ContenderSession.contender` now wraps a `SessionContender` enum (`Uninit` / `Init`)
   - `take_contender` / `put_contender` replaced by typed `take_uninitialized` / `take_initialized` / `put_initialized`
 - contender API ([#494](https://github.com/flashbots/contender/pull/494/changes))

--- a/crates/cli/src/commands/spam.rs
+++ b/crates/cli/src/commands/spam.rs
@@ -958,9 +958,11 @@ where
 
         _ = tokio::signal::ctrl_c() => {
             info!("CTRL-C received, stopping result collection.");
-            test_scenario.shutdown().await;
         }
     }
+
+    // Shut down the TxActor so its flush loop stops logging
+    test_scenario.shutdown().await;
 
     // Stop background tasks and print final summary
     if let Some(cancel) = funding_cancel {

--- a/crates/core/src/test_scenario.rs
+++ b/crates/core/src/test_scenario.rs
@@ -417,7 +417,7 @@ where
     /// Otherwise do nothing.
     pub async fn sync_nonces(&mut self) -> Result<()> {
         if self.should_sync_nonces {
-            println!("syncing nonces...");
+            info!("syncing nonces from RPC...");
             return sync_nonces(
                 &self.signer_map,
                 &mut self.nonces,

--- a/crates/report/src/command.rs
+++ b/crates/report/src/command.rs
@@ -273,6 +273,8 @@ pub async fn report(
             .map(|w| w[1] - w[0])
             .collect::<Vec<_>>(),
     );
+    let start_block = blocks.first().map(|b| b.header.number).unwrap_or(0);
+    let end_block = blocks.last().map(|b| b.header.number).unwrap_or(0);
 
     // cache data to file
     let cache_data = CacheFile::new(trace_data, blocks, data_dir);
@@ -385,14 +387,18 @@ pub async fn report(
         .collect();
 
     // compile report
+    info!(
+        "Generating report (run_ids: {start_run_id}-{end_run_id}) (blocks {} to {})",
+        start_block, end_block
+    );
     let mut blocks = cache_data.blocks;
     blocks.sort_by_key(|a| a.header.number);
     let report_metadata = ReportMetadata {
         scenario_name: scenario_title,
         start_run_id,
         end_run_id,
-        start_block: blocks.first().unwrap().header.number,
-        end_block: blocks.last().unwrap().header.number,
+        start_block,
+        end_block,
         rpc_url: rpc_url.to_string(),
         metrics,
         chart_data: ChartData {


### PR DESCRIPTION

## Motivation

confusing logs at the tail end of a campaign with `--report` passed; TxActor kept printing "unconfirmed txs: 0"

## Solution

- shutdown the scenario when spammer is done
- add an info log before running potentially time-consuming operations

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Ran `cargo +nightly clippy --workspace --lib --examples --tests --benches --all-features --locked --fix`
- [x] Ran `cargo fmt --all`
- [x] Note breaking changes in PR description, if applicable
- [x] update changelogs
    - [x] Update `CHANGELOG.md` in each affected crate
    - [x] add a high-level description in the [root changelog](../CHANGELOG.md)
