### PR TITLE
server webpage: fix log output from spam_progress reports

### DIFF
--- a/crates/cli/src/server/static/index.html
+++ b/crates/cli/src/server/static/index.html
@@ -361,8 +361,10 @@ function statusText(status) {
 }
 
 function trimLogLine(text) {
-  // Extract timestamp and strip metadata prefix
-  const m = text.match(/^(\S+Z)\s+\w+\s+\S+:\s*(?:\S+:\s*)?(.*)/s);
+  // Extract timestamp and strip metadata prefix.
+  // The optional group strips a secondary prefix (e.g. line number "185: ").
+  // It requires whitespace after the colon so it won't eat into JSON values.
+  const m = text.match(/^(\S+Z)\s+\w+\s+\S+:\s*(?:\S+:\s+)?(.*)/s);
   if (!m) return text;
   const d = new Date(m[1]);
   const ts = isNaN(d) ? '' : d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false });
@@ -938,11 +940,20 @@ controls.appendChild(makeCabinet('Spam', body => {
   body.appendChild(row);
   body.appendChild(spammerF.container);
   body.appendChild(nameF.container);
-  body.appendChild(receiptsF.container);
   const row2 = document.createElement('div'); row2.className = 'row';
-  row2.appendChild(runForeverF.container);
+  row2.appendChild(receiptsF.container);
   row2.appendChild(reportIntervalF.container);
   body.appendChild(row2);
+  body.appendChild(runForeverF.container);
+
+  // Hide report interval when receipts are off (progress data depends on receipts)
+  function syncReportInterval() {
+    const enabled = receiptsF.input.value === 'true';
+    reportIntervalF.container.style.display = enabled ? '' : 'none';
+    if (!enabled) reportIntervalF.input.value = '0';
+  }
+  receiptsF.input.addEventListener('change', syncReportInterval);
+  syncReportInterval();
 
   // Message element for feedback
   const msg = document.createElement('div');


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/flashbots/contender/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

- log output from spam_progress reports incorrectly parsed by the webpage
- confusing UX; if save_receipts isn't enabled, the metrics can't be collected and all metrics show as 0



<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- fix the regex that parses logs in the webpage
- hide the report_interval input when save_receipts is disabled

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Ran `cargo +nightly clippy --workspace --lib --examples --tests --benches --all-features --locked --fix`
- [x] Ran `cargo fmt --all`
- [x] Note breaking changes in PR description, if applicable
- [x] update changelogs
    - [x] Update `CHANGELOG.md` in each affected crate
    - [x] add a high-level description in the [root changelog](../CHANGELOG.md)
