### PR TITLE
bugfix/server cpu usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > Note: this file did not exist until after `v0.5.6`.
 
+## Unreleased
+
+- (rpc): fix CPU usage bugs ([#527](https://github.com/flashbots/contender/pull/527/changes))
+
 ## [0.10.0](https://github.com/flashbots/contender/releases/tag/v0.10.0) - 2026-04-20
 
 - (rpc): accept eth denominations (e.g. "1 eth") for min_balance ([#518](https://github.com/flashbots/contender/pull/518))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2224,6 +2224,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
+ "tokio-metrics",
  "tokio-stream",
  "tokio-util",
  "tower 0.4.13",
@@ -2657,7 +2658,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -2827,7 +2828,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3049,7 +3050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5202,7 +5203,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9447,7 +9448,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10231,7 +10232,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10406,6 +10407,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.108",
+]
+
+[[package]]
+name = "tokio-metrics"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9e81d53caf955549b1dec7af4ac2149e94cc25ed97b4a545151140281e2f528"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -11295,7 +11308,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ contender_engine_provider = { path = "crates/engine_provider/" }
 contender_report = { path = "crates/report/" }
 
 tokio = { version = "1.40.0" }
+tokio-metrics = { version = "0.5.0" }
 tokio-tungstenite = { version = "0.26", features = ["native-tls"] }
 tokio-util = "0.7"
 alloy = { version = "1.0.22" }

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- (rpc): fix CPU usage bugs ([#527](https://github.com/flashbots/contender/pull/527/changes))
+
 ## [0.10.0](https://github.com/flashbots/contender/releases/tag/v0.10.0) - 2026-04-20
 
 - (rpc): accept eth denominations (e.g. "1 eth") for min_balance ([#518](https://github.com/flashbots/contender/pull/518/changes))

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,7 +23,8 @@ contender_report = { workspace = true }
 nu-ansi-term = { workspace = true }
 console-subscriber = { workspace = true, optional = true }
 serde = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "tracing"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "tracing", "rt"] }
+tokio-metrics = { workspace = true, optional = true }
 tokio-util = { workspace = true }
 alloy = { workspace = true, features = [
     "full",
@@ -61,6 +62,7 @@ tempfile = "3.15.0"
 [features]
 default = []
 async-tracing = ["dep:console-subscriber"]
+tokio-metrics = ["dep:tokio-metrics"]
 
 [build-dependencies]
 syn = { version = "2", features = ["full"] }

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -8,7 +8,6 @@ use crate::{
     util::{check_private_keys, find_insufficient_balances, fund_accounts, load_seedfile},
     LATENCY_HIST as HIST, PROM,
 };
-use contender_core::util::get_block_time;
 use contender_core::{
     generator::{
         agent_pools::{AgentPools, AgentSpec},
@@ -16,6 +15,7 @@ use contender_core::{
     },
     test_scenario::{TestScenario, TestScenarioParams},
 };
+use contender_core::{util::get_block_time, CancellationToken};
 use contender_engine_provider::DEFAULT_BLOCK_TIME;
 use contender_testfile::TestConfig;
 use std::{
@@ -99,6 +99,7 @@ pub async fn setup(
         .await?;
     }
 
+    let cancel_token = CancellationToken::new();
     let params = TestScenarioParams {
         rpc_url: args.eth_json_rpc_args.rpc_url,
         builder_rpc_url: None,
@@ -123,6 +124,7 @@ pub async fn setup(
         params,
         engine_params.engine_provider,
         (&PROM, &HIST).into(),
+        &cancel_token,
     )
     .await?;
 
@@ -199,6 +201,7 @@ pub async fn setup(
 
         _ = tokio::signal::ctrl_c() => {
             warn!("Setup cancelled.");
+            cancel_token.cancel();
             is_done.store(true, Ordering::SeqCst);
         },
     }

--- a/crates/cli/src/commands/spam.rs
+++ b/crates/cli/src/commands/spam.rs
@@ -531,6 +531,7 @@ impl SpamCommandArgs {
             None
         };
 
+        let cancel_token = CancellationToken::new();
         let params = TestScenarioParams {
             rpc_url: self.spam_args.eth_json_rpc_args.rpc_args.rpc_url.clone(),
             builder_rpc_url: builder_url.to_owned(),
@@ -559,6 +560,7 @@ impl SpamCommandArgs {
             params,
             engine_params.engine_provider.clone(),
             (&PROM, &HIST).into(),
+            &cancel_token,
         )
         .await?;
 
@@ -573,6 +575,7 @@ impl SpamCommandArgs {
                 }
                 .into());
             }
+
             tokio::select! {
                 inner_res = async move {
                     if let Some(handle) = fcu_handle {
@@ -591,6 +594,14 @@ impl SpamCommandArgs {
                     Ok::<_, CliError>(())
                 } => {
                     inner_res
+                }
+                _ = cancel_token.cancelled() => {
+                    warn!("Setup cancelled.");
+                    return Err(
+                        CliError::Core(
+                            RuntimeErrorKind::InitializationCancelled.into()
+                        )
+                    );
                 }
             }?;
         }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -28,7 +28,28 @@ use tracing_subscriber::EnvFilter;
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> miette::Result<()> {
+    init_tokio_metrics();
     run().await.map_err(|e| e.into())
+}
+
+/// Initializes tokio metrics collection/logging thread.
+/// No-op if the "tokio-metrics" feature is disabled.
+fn init_tokio_metrics() {
+    #[cfg(feature = "tokio-metrics")]
+    {
+        use std::time::Duration;
+        use tokio_metrics::RuntimeMonitor;
+        let handle = tokio::runtime::Handle::current();
+        let monitor = RuntimeMonitor::new(&handle);
+        tokio::spawn(async move {
+            for interval in monitor.intervals() {
+                // pretty-print the metric interval
+                println!("{:#?}", interval);
+                // wait
+                tokio::time::sleep(Duration::from_millis(1000)).await;
+            }
+        });
+    }
 }
 
 async fn run() -> Result<(), contender_cli::Error> {

--- a/crates/cli/src/server/rpc_server/server.rs
+++ b/crates/cli/src/server/rpc_server/server.rs
@@ -158,7 +158,7 @@ impl ContenderRpcServer for ContenderServer {
 
     async fn remove_session(&self, id: usize) -> jsonrpsee::core::RpcResult<()> {
         let mut sessions = self.sessions.write().await;
-        sessions.remove_session(id);
+        sessions.remove_session(id).await;
         Ok(())
     }
 

--- a/crates/cli/src/server/rpc_server/server.rs
+++ b/crates/cli/src/server/rpc_server/server.rs
@@ -80,15 +80,14 @@ impl ContenderRpcServer for ContenderServer {
         params: AddSessionParams,
     ) -> jsonrpsee::core::RpcResult<ContenderSessionInfo> {
         let session_seed;
-        let info;
-        {
+        let info = {
             let mut sessions = self.sessions.write().await;
             session_seed = RandSeed::seed_from_bytes(&sessions.num_sessions().to_be_bytes());
             let session = sessions
                 .add_session(params.to_new_session_params(session_seed).await?)
                 .await?;
-            info = session.info.clone();
-        }
+            session.info.clone()
+        };
 
         let session_id = info.id;
         let sessions = Arc::clone(&self.sessions);
@@ -108,7 +107,6 @@ impl ContenderRpcServer for ContenderServer {
                         let mut lock = sessions.write().await;
                         lock.take_uninitialized(session_id)
                     };
-
                     let Some(contender) = contender else {
                         return;
                     };
@@ -123,7 +121,7 @@ impl ContenderRpcServer for ContenderServer {
                             }
                         }
                         Err(e) => {
-                            let msg = e.to_string();
+                            let msg = format!("{e:?}");
                             let mut lock = sessions.write().await;
                             if let Some(session) = lock.get_session_mut(session_id) {
                                 session.info.status = SessionStatus::Failed(msg.clone());
@@ -401,15 +399,16 @@ impl ContenderRpcServer for ContenderServer {
 
     async fn stop(&self, session_id: usize) -> jsonrpsee::core::RpcResult<String> {
         let span = tracing::info_span!("session_stop", id = session_id);
-        let sessions = self.sessions.read().await;
-        let Some(session) = sessions.get_session(session_id) else {
-            return Err(ContenderRpcError::SessionNotFound(session_id).into());
-        };
-        let Some(ref token) = session.spam_cancel else {
-            return Err(ContenderRpcError::SessionNotBusy(session_id).into());
-        };
-        token.cancel();
-        drop(sessions);
+        {
+            let sessions = self.sessions.read().await;
+            let Some(session) = sessions.get_session(session_id) else {
+                return Err(ContenderRpcError::SessionNotFound(session_id).into());
+            };
+            let Some(ref token) = session.spam_cancel else {
+                return Err(ContenderRpcError::SessionNotBusy(session_id).into());
+            };
+            token.cancel();
+        }
         {
             let _enter = span.enter();
             info!("Sent stop signal to session {session_id}");

--- a/crates/cli/src/server/sessions.rs
+++ b/crates/cli/src/server/sessions.rs
@@ -294,14 +294,30 @@ impl ContenderSessionCache {
         }
     }
 
-    pub fn remove_session(&mut self, id: SessionId) {
-        if let Some(session) = self.get_session(id) {
+    pub async fn remove_session(&mut self, id: SessionId) {
+        // If the session exists and has an initialized Contender, shut it down first.
+        if let Some(session) = self.get_session_mut(id) {
             // Stop any running spam before tearing down.
             if let Some(ref token) = session.spam_cancel {
                 token.cancel();
             }
             // Cancel subscriber streams before dropping the session.
             session.cancel.cancel();
+
+            // If the session has an initialized Contender, take it and shut it down.
+            let maybe_contender = match session.contender.take() {
+                Some(SessionContender::Init(c)) => Some(c),
+                other => {
+                    session.contender = other;
+                    None
+                }
+            };
+            if let Some(mut contender) = maybe_contender {
+                // Call shutdown on the scenario to stop all background actors.
+                // This is async, so we must await it.
+                let scenario = contender.scenario_mut();
+                scenario.shutdown().await;
+            }
         }
         // Deregister the log sink.
         if let Ok(mut sinks) = self.log_sinks.try_write() {

--- a/crates/cli/src/server/sessions.rs
+++ b/crates/cli/src/server/sessions.rs
@@ -109,11 +109,12 @@ impl ContenderSession {
             .create_contender(params.test_config, params.options)
             .await?;
         let (log_channel, _) = broadcast::channel(4096);
+        let cancel = contender.cancel_token();
         Ok(Self {
             info,
             contender: Some(SessionContender::Uninit(contender)),
             log_channel,
-            cancel: CancellationToken::new(),
+            cancel,
             spam_cancel: None,
             funder: None,
             agent_store: None,
@@ -301,12 +302,14 @@ impl ContenderSessionCache {
             if let Some(ref token) = session.spam_cancel {
                 token.cancel();
             }
-            // Cancel subscriber streams before dropping the session.
-            session.cancel.cancel();
 
             // If the session has an initialized Contender, take it and shut it down.
             let maybe_contender = match session.contender.take() {
                 Some(SessionContender::Init(c)) => Some(c),
+                Some(SessionContender::Uninit(c)) => {
+                    c.cancel();
+                    None
+                }
                 other => {
                     session.contender = other;
                     None
@@ -318,6 +321,9 @@ impl ContenderSessionCache {
                 let scenario = contender.scenario_mut();
                 scenario.shutdown().await;
             }
+
+            // Cancel subscriber streams before dropping the session.
+            session.cancel.cancel();
         }
         // Deregister the log sink.
         if let Ok(mut sinks) = self.log_sinks.try_write() {

--- a/crates/cli/src/server/static/openrpc.json
+++ b/crates/cli/src/server/static/openrpc.json
@@ -18,7 +18,7 @@
       "BundleCallDefinition": {"file":"crates/core/src/generator/function_def.rs","line":53},
       "BundleTypeCli": {"file":"crates/cli/src/commands/common.rs","line":426},
       "CompiledContract": {"file":"crates/core/src/generator/create_def.rs","line":8},
-      "ContenderSessionInfo": {"file":"crates/cli/src/server/sessions.rs","line":127},
+      "ContenderSessionInfo": {"file":"crates/cli/src/server/sessions.rs","line":128},
       "CreateDefinition": {"file":"crates/core/src/generator/create_def.rs","line":65},
       "CustomContractCliArgs": {"file":"crates/cli/src/default_scenarios/custom_contract.rs","line":17},
       "EngineMessageVersion": {"file":"crates/cli/src/commands/common.rs","line":268},

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- (rpc): fix CPU usage bugs ([#527](https://github.com/flashbots/contender/pull/527/changes))
+
+### Breaking changes
+
+*from [#527](https://github.com/flashbots/contender/pull/527/changes):*
+
+- `TestScenario::new` added a param: `cancel_token: &CancellationToken`
+
 ## [0.10.0](https://github.com/flashbots/contender/releases/tag/v0.10.0) - 2026-04-20
 
 - refactor `utils::{parse_value, parse_value_opt}` to accept numbers or strings for deser ([#518](https://github.com/flashbots/contender/pull/518/changes))

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -71,6 +71,9 @@ pub enum RuntimeErrorKind {
     #[error("no genesis block found")]
     GenesisBlockMissing,
 
+    #[error("contender initialization was cancelled by user")]
+    InitializationCancelled,
+
     #[error("NamedTxRequest requires a 'from' address: {0:?}")]
     NamedTxMissingFromAddress(Box<NamedTxRequest>),
 

--- a/crates/core/src/orchestrator.rs
+++ b/crates/core/src/orchestrator.rs
@@ -782,6 +782,10 @@ where
             handle.await_flush().await;
         }
 
+        // prepare for next run; resets cancel token & flush channels so they're ready for another run if desired.
+        // if another run is not desired, this operation is cheap; no need to do any checks, we'll just drop the handles.
+        scenario.prepare_for_run().await?;
+
         result
     }
 

--- a/crates/core/src/orchestrator.rs
+++ b/crates/core/src/orchestrator.rs
@@ -6,6 +6,7 @@ use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
 use crate::{
     agent_controller::AgentClass,
     db::{DbOps, MockDb, SpamDuration, SpamRunRequest},
+    error::RuntimeErrorKind,
     generator::{
         agent_pools::AgentSpec,
         seeder::{rand_seed::SeedGenerator, Seeder},
@@ -64,6 +65,8 @@ where
     pub rpc_batch_size: u64,
     pub scenario_label: Option<String>,
     pub send_raw_tx_sync: bool,
+    /// Cancellation token that can be used to cancel the entire scenario run, including setup and spam.
+    pub cancel_token: CancellationToken,
 }
 
 impl<P> ContenderCtx<MockDb, RandSeed, P>
@@ -233,6 +236,7 @@ where
             params,
             self.auth_provider.clone(),
             self.prometheus.clone(),
+            &self.cancel_token,
         )
         .await
     }
@@ -353,6 +357,7 @@ where
             rpc_batch_size: self.rpc_batch_size,
             scenario_label: self.scenario_label,
             send_raw_tx_sync: self.send_raw_tx_sync,
+            cancel_token: CancellationToken::new(),
         }
     }
 }
@@ -569,9 +574,30 @@ where
     /// Funds agent accounts, then runs contract deployments and setup transactions.
     ///
     /// Consumes the uninitialized `Contender` and returns an initialized one.
+    ///
+    /// If the cancellation token in `self.ctx` is triggered before initialization completes,
+    /// the process will be aborted and any in-progress tasks will be shutdown.
+    /// In this case, an error indicating that initialization was cancelled will be returned.
     pub async fn initialize(self) -> Result<Contender<D, S, P, Initialized<D, S, P>>> {
         let mut scenario = self.ctx.build_scenario().await?;
+        let cancel = self.ctx.cancel_token.clone();
 
+        tokio::select! {
+            res = self.initialize_inner(&mut scenario) => {
+                return res;
+            },
+            _ = cancel.cancelled() => {
+                // shutdown the scenario to stop any in-progress tasks
+                scenario.shutdown().await;
+                return Err(RuntimeErrorKind::InitializationCancelled.into())
+            }
+        }
+    }
+
+    async fn initialize_inner(
+        self,
+        scenario: &mut TestScenario<D, S, P>,
+    ) -> Result<Contender<D, S, P, Initialized<D, S, P>>> {
         // Estimate setup cost via Anvil simulation and error if funding is insufficient
         let setup_cost = scenario.estimate_setup_cost().await?;
         if self.ctx.funding < setup_cost {
@@ -601,7 +627,7 @@ where
         Ok(Contender {
             ctx: self.ctx,
             state: Initialized {
-                scenario: scenario.into(),
+                scenario: scenario.to_owned().into(),
             },
         })
     }
@@ -625,6 +651,15 @@ where
             .spam(spammer, callback, opts, cancel_token)
             .await?;
         Ok(contender)
+    }
+
+    /// Cancels the initialization process if it's still running. If initialization has already completed, this has no effect.
+    pub fn cancel(self) {
+        self.ctx.cancel_token.cancel();
+    }
+
+    pub fn cancel_token(&self) -> CancellationToken {
+        self.ctx.cancel_token.clone()
     }
 }
 

--- a/crates/core/src/orchestrator.rs
+++ b/crates/core/src/orchestrator.rs
@@ -842,3 +842,59 @@ where
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{generator::util::test::spawn_anvil, test_scenario::tests::MockConfig};
+
+    #[tokio::test]
+    async fn cancel_token_shuts_down_contender() -> Result<(), Box<dyn std::error::Error>> {
+        use crate::{generator::RandSeed, Contender, ContenderCtx};
+
+        let anvil = spawn_anvil();
+        let ctx = ContenderCtx::builder(
+            MockConfig,
+            crate::db::MockDb,
+            RandSeed::new(),
+            anvil.endpoint(),
+        )
+        .build();
+        let cancel_token = ctx.cancel_token.clone();
+        let contender = Contender::new(ctx);
+
+        // run contender initialization in a separate task so we can cancel it while it's running
+        let init_handle = tokio::task::spawn(async {
+            let res = contender.initialize().await;
+            if res.is_err() {
+                return res;
+            }
+            let contender = res.unwrap();
+            println!("cancelled: {}", contender.ctx.cancel_token.is_cancelled());
+            Ok(contender)
+        });
+
+        // cancel whatever contender is doing
+        cancel_token.cancel();
+        assert!(cancel_token.is_cancelled());
+
+        // check initialization result; should have returned a specific error
+        let res = init_handle.await?;
+        assert!(res.is_err());
+        match res {
+            Err(e) => match e {
+                crate::Error::Runtime(err) => {
+                    assert!(
+                        matches!(err, crate::error::RuntimeErrorKind::InitializationCancelled),
+                        "unexpected error: {err}"
+                    );
+                }
+                _ => {
+                    panic!("Expected a Runtime error, got: {e}");
+                }
+            },
+            Ok(_) => panic!("Expected initialization to be cancelled, but it succeeded"),
+        }
+
+        Ok(())
+    }
+}

--- a/crates/core/src/orchestrator.rs
+++ b/crates/core/src/orchestrator.rs
@@ -584,12 +584,12 @@ where
 
         tokio::select! {
             res = self.initialize_inner(&mut scenario) => {
-                return res;
+                res
             },
             _ = cancel.cancelled() => {
                 // shutdown the scenario to stop any in-progress tasks
                 scenario.shutdown().await;
-                return Err(RuntimeErrorKind::InitializationCancelled.into())
+                Err(RuntimeErrorKind::InitializationCancelled.into())
             }
         }
     }

--- a/crates/core/src/orchestrator.rs
+++ b/crates/core/src/orchestrator.rs
@@ -864,13 +864,8 @@ mod tests {
 
         // run contender initialization in a separate task so we can cancel it while it's running
         let init_handle = tokio::task::spawn(async {
-            let res = contender.initialize().await;
-            if res.is_err() {
-                return res;
-            }
-            let contender = res.unwrap();
-            println!("cancelled: {}", contender.ctx.cancel_token.is_cancelled());
-            Ok(contender)
+            let res = contender.initialize().await?;
+            Ok::<_, crate::Error>(res)
         });
 
         // cancel whatever contender is doing

--- a/crates/core/src/spammer/blockwise.rs
+++ b/crates/core/src/spammer/blockwise.rs
@@ -73,6 +73,7 @@ mod tests {
     };
     use contender_bundle_provider::bundle::BundleType;
     use tokio::sync::OnceCell;
+    use tokio_util::sync::CancellationToken;
 
     use crate::{
         db::MockDb,
@@ -137,6 +138,7 @@ mod tests {
             },
             None,
             (&PROM, &HIST).into(),
+            &CancellationToken::new(),
         )
         .await
         .unwrap();

--- a/crates/core/src/spammer/tx_actor.rs
+++ b/crates/core/src/spammer/tx_actor.rs
@@ -531,7 +531,7 @@ async fn flush_loop<D: DbOps + Send + Sync + 'static>(
         let blocks_start = target_block;
 
         // Process blocks one at a time, refreshing the snapshot after each.
-        for bn in target_block..new_block {
+        for bn in blocks_start..new_block {
             match process_block_receipts(&cache_snapshot, &db, &rpc, ctx.run_id, bn).await {
                 Ok(confirmed) => {
                     let _ = flush_sender

--- a/crates/core/src/spammer/tx_actor.rs
+++ b/crates/core/src/spammer/tx_actor.rs
@@ -380,29 +380,28 @@ where
             if self.status == ActorStatus::ShuttingDown {
                 break;
             }
-            println!("ahh im TxActor im doing somethiiiing");
 
             tokio::select! {
                 msg = self.receiver.recv() => {
-                    println!("TxActor received a message");
+                    tracing::trace!("TxActor received a message");
                     if let Some(msg) = msg {
-                        println!("message is Some, handling it");
+                        tracing::trace!("message is Some, handling it");
                         self.handle_message(msg)?;
                     }
                 }
 
                 req = self.flush_receiver.recv() => {
-                    println!("TxActor received a flush message");
+                    tracing::trace!("TxActor received a flush message");
                     if let Some(req) = req {
-                        println!("flush_request is Some, handling it");
+                        tracing::trace!("flush_request is Some, handling it");
                         self.handle_flush_request(req);
                     }
                 }
 
                 mark = self.flashblock_receiver.recv() => {
-                    println!("TxActor received a flashblock message");
+                    tracing::trace!("TxActor received a flashblock message");
                     if let Some(mark) = mark {
-                        println!("flashblock mark is Some, handling it");
+                        tracing::trace!("flashblock mark is Some, handling it");
                         self.handle_flashblock_mark(mark);
                     }
                 }
@@ -586,10 +585,10 @@ async fn process_block_receipts<D: DbOps + Send + Sync + 'static>(
     run_id: u64,
     target_block_num: u64,
 ) -> Result<Vec<TxHash>> {
-    info!("unconfirmed txs: {}", cache_snapshot.len());
-
     if cache_snapshot.is_empty() {
         return Ok(Vec::new());
+    } else {
+        info!("unconfirmed txs: {}", cache_snapshot.len());
     }
 
     // Wait for block to appear

--- a/crates/core/src/spammer/tx_actor.rs
+++ b/crates/core/src/spammer/tx_actor.rs
@@ -418,37 +418,34 @@ async fn flush_loop<D: DbOps + Send + Sync + 'static>(
     let mut stale_blocks: u64 = 0;
     let mut last_pending_count: usize = usize::MAX;
 
-    loop {
+    // Phase 1: Wait for context to be initialized.
+    // Avoids burning CPU with snapshot round-trips when no spam run is active.
+    let mut target_block = loop {
         interval.tick().await;
 
-        // Request snapshot from message handler
         let (reply_tx, reply_rx) = oneshot::channel();
         if flush_sender
             .send(FlushRequest::GetSnapshot { reply: reply_tx })
             .await
             .is_err()
         {
-            // Message handler shut down
-            break;
+            return;
         }
 
-        let (cache_snapshot, ctx) = match reply_rx.await {
-            Ok(data) => data,
-            Err(_) => continue,
-        };
-
-        let Some(ctx) = ctx else {
-            debug!("TxActor context not initialized.");
-            continue;
-        };
-
-        // If cancel_token is set (sending is done) and cache is empty, we're done.
-        if cancel_token.is_cancelled() && cache_snapshot.is_empty() {
-            info!("all receipts processed, shutting down receipt collection.");
-            break;
+        match reply_rx.await {
+            Ok((_, Some(ctx))) => break ctx.target_block,
+            Ok((_, None)) => {
+                debug!("TxActor context not initialized.");
+            }
+            Err(_) => return,
         }
+    };
 
-        // Get current block number
+    // Phase 2: Process blocks as they arrive.
+    loop {
+        interval.tick().await;
+
+        // Check for new blocks BEFORE requesting a snapshot to avoid unnecessary channel traffic.
         let new_block = match rpc.get_block_number().await {
             Ok(n) => n,
             Err(e) => {
@@ -457,16 +454,62 @@ async fn flush_loop<D: DbOps + Send + Sync + 'static>(
             }
         };
 
-        if ctx.target_block >= new_block {
+        if target_block >= new_block {
+            // No new blocks; if cancel is set, check whether the cache is already empty.
+            if cancel_token.is_cancelled() {
+                let (reply_tx, reply_rx) = oneshot::channel();
+                if flush_sender
+                    .send(FlushRequest::GetSnapshot { reply: reply_tx })
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+                if let Ok((snapshot, _)) = reply_rx.await {
+                    if snapshot.is_empty() {
+                        info!("all receipts processed, shutting down receipt collection.");
+                        break;
+                    }
+                }
+            }
             continue;
         }
 
-        // Process blocks one at a time, refreshing the snapshot after each
-        let mut cache_snapshot = cache_snapshot;
-        let run_id = ctx.run_id;
+        // New blocks available — request snapshot now.
+        let (reply_tx, reply_rx) = oneshot::channel();
+        if flush_sender
+            .send(FlushRequest::GetSnapshot { reply: reply_tx })
+            .await
+            .is_err()
+        {
+            break;
+        }
 
-        for bn in ctx.target_block..new_block {
-            match process_block_receipts(&cache_snapshot, &db, &rpc, run_id, bn).await {
+        let (mut cache_snapshot, ctx) = match reply_rx.await {
+            Ok((snapshot, Some(ctx))) => {
+                target_block = ctx.target_block;
+                (snapshot, ctx)
+            }
+            Ok((_, None)) => continue,
+            Err(_) => break,
+        };
+
+        // Re-check after context refresh.
+        if target_block >= new_block {
+            continue;
+        }
+
+        // If cancel_token is set and cache is empty, we're done.
+        if cancel_token.is_cancelled() && cache_snapshot.is_empty() {
+            info!("all receipts processed, shutting down receipt collection.");
+            break;
+        }
+
+        let blocks_start = target_block;
+
+        // Process blocks one at a time, refreshing the snapshot after each.
+        for bn in target_block..new_block {
+            match process_block_receipts(&cache_snapshot, &db, &rpc, ctx.run_id, bn).await {
                 Ok(confirmed) => {
                     let _ = flush_sender
                         .send(FlushRequest::RemoveConfirmed {
@@ -485,8 +528,9 @@ async fn flush_loop<D: DbOps + Send + Sync + 'static>(
                         return;
                     }
                     match reply_rx.await {
-                        Ok((new_snapshot, Some(_))) => {
+                        Ok((new_snapshot, Some(ctx))) => {
                             cache_snapshot = new_snapshot;
+                            target_block = ctx.target_block;
                         }
                         Ok((_, None)) => break,
                         Err(_) => break,
@@ -504,11 +548,14 @@ async fn flush_loop<D: DbOps + Send + Sync + 'static>(
             }
         }
 
+        // Ensure we advance past all processed blocks.
+        target_block = target_block.max(new_block);
+
         // Track stale blocks: if sending is done and pending count hasn't changed, increment.
         if cancel_token.is_cancelled() && !cache_snapshot.is_empty() {
             let current_count = cache_snapshot.len();
             if current_count == last_pending_count {
-                stale_blocks += new_block.saturating_sub(ctx.target_block).max(1);
+                stale_blocks += new_block.saturating_sub(blocks_start).max(1);
             } else {
                 stale_blocks = 0;
                 last_pending_count = current_count;

--- a/crates/core/src/spammer/tx_actor.rs
+++ b/crates/core/src/spammer/tx_actor.rs
@@ -9,7 +9,7 @@ use alloy::{
 };
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, trace, warn};
 use url::Url;
 
 use crate::{
@@ -102,6 +102,8 @@ where
     flush_receiver: mpsc::Receiver<FlushRequest>,
     /// Dedicated flashblock marks receiver (large buffer to handle high TPS)
     flashblock_receiver: mpsc::Receiver<FlashblockMark>,
+    /// dedicated stop signal receiver (separate from API messages to ensure it is always received)
+    stop_receiver: mpsc::Receiver<()>,
     db: Arc<D>,
     cache: HashMap<TxHash, PendingRunTx>,
     ctx: Option<ActorContext>,
@@ -189,12 +191,14 @@ where
         receiver: mpsc::Receiver<TxActorMessage>,
         flush_receiver: mpsc::Receiver<FlushRequest>,
         flashblock_receiver: mpsc::Receiver<FlashblockMark>,
+        stop_receiver: mpsc::Receiver<()>,
         db: Arc<D>,
     ) -> Self {
         Self {
             receiver,
             flush_receiver,
             flashblock_receiver,
+            stop_receiver,
             db,
             cache: HashMap::new(),
             ctx: None,
@@ -247,8 +251,13 @@ where
                 self.ctx = Some(ctx);
             }
             TxActorMessage::Stop { on_stop } => {
+                self.flashblock_receiver.close();
+                self.flush_receiver.close();
+                self.receiver.close();
                 self.status = ActorStatus::ShuttingDown;
-                on_stop.send(()).map_err(|_| CallbackError::Stop)?;
+                on_stop
+                    .send(())
+                    .map_err(|e| CallbackError::OneshotSend(format!("Stop: {:?}", e)))?;
             }
             TxActorMessage::SentRunTx {
                 tx_hash,
@@ -382,6 +391,14 @@ where
             }
 
             tokio::select! {
+                _ = self.stop_receiver.recv() => {
+                    // Received stop signal, begin shutdown process
+                    let (sender, receiver) = oneshot::channel();
+                    self.handle_message(TxActorMessage::Stop { on_stop: sender })?;
+                    // Wait for confirmation that shutdown message was processed
+                    let _ = receiver.await;
+                    debug!("TxActor has shut down.");
+                }
                 msg = self.receiver.recv() => {
                     tracing::trace!("TxActor received a message");
                     if let Some(msg) = msg {
@@ -441,7 +458,7 @@ async fn flush_loop<D: DbOps + Send + Sync + 'static>(
         match reply_rx.await {
             Ok((_, Some(ctx))) => break ctx.target_block,
             Ok((_, None)) => {
-                debug!("TxActor context not initialized.");
+                trace!("TxActor context not initialized.");
             }
             Err(_) => return,
         }
@@ -698,6 +715,7 @@ fn get_tx_error(
 #[derive(Debug)]
 pub struct TxActorHandle {
     sender: mpsc::Sender<TxActorMessage>,
+    stop_sender: mpsc::Sender<()>,
     flush_complete: std::sync::Mutex<CancellationToken>,
     // we need to keep the sender side of the flashblock channel here to prevent it from being dropped.
     fb_sender: mpsc::Sender<FlashblockMark>,
@@ -725,13 +743,22 @@ impl TxActorHandle {
             FlashblocksClient::preflight(ws_url).await?;
         }
 
+        // dedicated stop channel to signal shutdown (separate from API messages to ensure it is always received)
+        let (stop_sender, stop_receiver) = mpsc::channel(1);
+        // generic channel for API messages to the actor (cache updates, dump requests, etc.)
         let (sender, receiver) = mpsc::channel(bufsize);
         // Channel for flush task to communicate with message handler
         let (flush_sender, flush_receiver) = mpsc::channel(64);
         // Dedicated channel for flashblock marks (large buffer to handle high TPS)
         let (fb_sender, fb_receiver) = mpsc::channel(10_000);
 
-        let mut actor = TxActor::new(receiver, flush_receiver, fb_receiver, db.clone());
+        let mut actor = TxActor::new(
+            receiver,
+            flush_receiver,
+            fb_receiver,
+            stop_receiver,
+            db.clone(),
+        );
 
         // Spawn the message handler task (owns the cache)
         crate::spawn_with_session(async move {
@@ -763,6 +790,7 @@ impl TxActorHandle {
             sender,
             flush_complete: std::sync::Mutex::new(flush_complete),
             fb_sender,
+            stop_sender,
         })
     }
 
@@ -902,13 +930,10 @@ impl TxActorHandle {
 
     /// Stops the actor, terminating all pending tasks.
     pub async fn stop(&self) -> Result<()> {
-        let (sender, receiver) = oneshot::channel();
-        self.sender
-            .send(TxActorMessage::Stop { on_stop: sender })
+        self.stop_sender
+            .send(())
             .await
-            .map_err(Box::new)
-            .map_err(CallbackError::from)?;
-        Ok(receiver.await.map_err(CallbackError::OneshotReceive)?)
+            .map_err(|_| CallbackError::Stop.into())
     }
 
     pub async fn init_ctx(&self, ctx: ActorContext) -> Result<()> {

--- a/crates/core/src/spammer/tx_actor.rs
+++ b/crates/core/src/spammer/tx_actor.rs
@@ -860,12 +860,6 @@ impl TxActorHandle {
         self.fb_sender.is_closed()
     }
 
-    pub async fn close_fb_stream(&self) -> Result<()> {
-        // Dropping the sender will close the channel and stop the flashblock listener task.
-        drop(self.fb_sender.clone());
-        Ok(())
-    }
-
     pub async fn reopen_fb_stream(
         &mut self,
         ws_url: Url,

--- a/crates/core/src/spammer/tx_actor.rs
+++ b/crates/core/src/spammer/tx_actor.rs
@@ -380,22 +380,29 @@ where
             if self.status == ActorStatus::ShuttingDown {
                 break;
             }
+            println!("ahh im TxActor im doing somethiiiing");
 
             tokio::select! {
                 msg = self.receiver.recv() => {
+                    println!("TxActor received a message");
                     if let Some(msg) = msg {
+                        println!("message is Some, handling it");
                         self.handle_message(msg)?;
                     }
                 }
 
                 req = self.flush_receiver.recv() => {
+                    println!("TxActor received a flush message");
                     if let Some(req) = req {
+                        println!("flush_request is Some, handling it");
                         self.handle_flush_request(req);
                     }
                 }
 
                 mark = self.flashblock_receiver.recv() => {
+                    println!("TxActor received a flashblock message");
                     if let Some(mark) = mark {
+                        println!("flashblock mark is Some, handling it");
                         self.handle_flashblock_mark(mark);
                     }
                 }
@@ -693,6 +700,8 @@ fn get_tx_error(
 pub struct TxActorHandle {
     sender: mpsc::Sender<TxActorMessage>,
     flush_complete: std::sync::Mutex<CancellationToken>,
+    // we need to keep the sender side of the flashblock channel here to prevent it from being dropped.
+    fb_sender: mpsc::Sender<FlashblockMark>,
 }
 
 #[derive(Debug)]
@@ -743,6 +752,7 @@ impl TxActorHandle {
 
         // Spawn the flashblocks listener task if URL is provided
         if let Some(ws_url) = flashblocks_ws_url {
+            let fb_sender = fb_sender.clone();
             crate::spawn_with_session(async move {
                 if let Err(e) = FlashblocksClient::listen(&ws_url, fb_sender, cancel_token).await {
                     error!("{}", e);
@@ -753,6 +763,7 @@ impl TxActorHandle {
         Ok(Self {
             sender,
             flush_complete: std::sync::Mutex::new(flush_complete),
+            fb_sender,
         })
     }
 
@@ -843,6 +854,31 @@ impl TxActorHandle {
             .map_err(CallbackError::from)?;
         let cache_len = receiver.await.map_err(CallbackError::from)?;
         Ok(cache_len)
+    }
+
+    pub fn is_fb_stream_closed(&self) -> bool {
+        self.fb_sender.is_closed()
+    }
+
+    pub async fn close_fb_stream(&self) -> Result<()> {
+        // Dropping the sender will close the channel and stop the flashblock listener task.
+        drop(self.fb_sender.clone());
+        Ok(())
+    }
+
+    pub async fn reopen_fb_stream(
+        &mut self,
+        ws_url: Url,
+        cancel_token: CancellationToken,
+    ) -> Result<tokio::sync::mpsc::Receiver<FlashblockMark>> {
+        let (fb_sender, fb_receiver) = mpsc::channel(10_000);
+        self.fb_sender.clone_from(&fb_sender);
+        crate::spawn_with_session(async move {
+            if let Err(e) = FlashblocksClient::listen(&ws_url, fb_sender, cancel_token).await {
+                error!("{}", e);
+            }
+        });
+        Ok(fb_receiver)
     }
 
     /// Removes an existing tx in the cache.

--- a/crates/core/src/test_scenario.rs
+++ b/crates/core/src/test_scenario.rs
@@ -259,6 +259,12 @@ where
     S: SeedGenerator + Send + Sync + Clone,
     P: PlanConfig<String> + Templater<String> + Send + Sync + Clone,
 {
+    /// Create a new `TestScenario` with generic parameters. Not recommended for general use.
+    /// See `orchestrator::ContenderCtx` instead.
+    ///
+    /// `cancel_token` is used to create a child token for internal use,
+    /// allowing the scenario to cancel its own internal tasks without affecting the parent context,
+    /// but the parent token can still cancel the child tasks if needed.
     pub async fn new(
         config: P,
         db: Arc<D>,
@@ -266,7 +272,10 @@ where
         params: TestScenarioParams,
         auth_provider: Option<Arc<dyn ControlChain + Send + Sync + 'static>>,
         prometheus: PrometheusCollector,
+        cancel_token: &CancellationToken,
     ) -> Result<Self> {
+        // ensure we use a child token for any internal operations, to prevent interference with the parent context
+        let cancel_token = cancel_token.child_token();
         let TestScenarioParams {
             rpc_url,
             builder_rpc_url,
@@ -352,8 +361,6 @@ where
         if chain_id != chain_id_builder {
             return Err(RuntimeErrorKind::ChainIdMismatch(chain_id, chain_id_builder).into());
         }
-
-        let cancel_token = CancellationToken::new();
 
         // default msg_handle to handle txs sent on rpc_url
         let msg_handle = Arc::new(
@@ -560,6 +567,7 @@ where
             },
             None,
             (&PROM, &HIST).into(),
+            &self.ctx.cancel_token,
         )
         .await?;
 
@@ -588,10 +596,20 @@ where
         }
 
         debug!("deploying sim contracts...");
-        scenario.deploy_contracts().await?;
-        scenario.sync_nonces().await?;
-        debug!("sim contracts deployed, running setup...");
-        scenario.run_setup().await?;
+        tokio::select! {
+            res = async {
+                scenario.deploy_contracts().await?;
+                scenario.sync_nonces().await?;
+                debug!("sim contracts deployed, running setup...");
+                scenario.run_setup().await?;
+                Ok::<_, crate::Error>(())
+            } => res,
+            _ = self.ctx.cancel_token.cancelled() => {
+                info!("cancelling setup simulation...");
+                scenario.shutdown().await;
+                return Err(RuntimeErrorKind::InitializationCancelled.into());
+            }
+        }?;
 
         let mut total_cost = U256::ZERO;
         for (addr, start_balance) in &start_balances {
@@ -718,7 +736,7 @@ where
             .with_timeout(Some(Duration::from_secs(30)));
 
         // watch pending transaction
-        let receipt = res.get_receipt().await.expect("failed to get receipt");
+        let receipt = res.get_receipt().await?;
         let contract_address = receipt.contract_address.unwrap_or_default();
         debug!("contract address: {contract_address}");
 
@@ -1707,6 +1725,7 @@ where
             },
             None,
             (&PROM, &HIST).into(),
+            &self.ctx.cancel_token,
         )
         .await?;
 
@@ -1799,6 +1818,7 @@ where
         for msg_handle in self.msg_handles.values() {
             tokio::select! {
                 _ = self.ctx.cancel_token.cancelled() => {
+                    self.tx_actor().stop().await.ok();
                 }
                 _ = async {
                     let mut last_cache_len = usize::MAX;
@@ -1872,13 +1892,14 @@ where
     }
 
     pub async fn shutdown(&mut self) {
-        self.ctx.cancel_token.cancel();
         // Stop all actors
         for (name, handle) in &self.msg_handles {
             if let Err(e) = handle.stop().await {
                 debug!("Error stopping actor '{}': {:?}", name, e);
             }
         }
+
+        self.ctx.cancel_token.cancel();
     }
 
     pub async fn is_shutdown(&self) -> bool {
@@ -2111,6 +2132,7 @@ pub mod tests {
     use std::sync::Arc;
     use std::time::Duration;
     use tokio::sync::OnceCell;
+    use tokio_util::sync::CancellationToken;
 
     use super::{TestScenarioParams, SETUP_CONCURRENCY_LIMIT};
 
@@ -2319,6 +2341,7 @@ pub mod tests {
             },
             None,
             (&PROM, &HIST).into(),
+            &CancellationToken::new(),
         )
         .await?;
 
@@ -2861,6 +2884,7 @@ pub mod tests {
             },
             None,
             (&PROM, &HIST).into(),
+            &CancellationToken::new(),
         )
         .await
         .unwrap();

--- a/crates/testfile/src/lib.rs
+++ b/crates/testfile/src/lib.rs
@@ -319,6 +319,7 @@ pub mod tests {
             },
             None,
             (&PROM, &HIST).into(),
+            &Default::default(),
         )
         .await
         .unwrap();
@@ -374,6 +375,7 @@ pub mod tests {
             },
             None,
             (&PROM, &HIST).into(),
+            &Default::default(),
         )
         .await
         .unwrap();
@@ -399,6 +401,7 @@ pub mod tests {
             },
             None,
             (&PROM, &HIST).into(),
+            &Default::default(),
         )
         .await
         .unwrap();
@@ -508,6 +511,7 @@ value = \"1eth\"
             default_scenario_params(anvil),
             None,
             (&PROM, &HIST).into(),
+            &Default::default(),
         )
         .await
         .unwrap()


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/flashbots/contender/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

CPU usage from server sessions was insane. From htop, I was getting ~2.6% CPU usage per session added, without even starting a spammer.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

There was a hot loop in [`TxActor::run`](https://github.com/flashbots/contender/blob/main/crates/core/src/spammer/tx_actor.rs). When stopping a spammer, we shut down the scenario via `scenario.ctx.cancel_token.cancel()`. That dropped owned mpsc sender handles, which caused the receiver handles to default to an instant-return condition (returning `None`), which when evaluated inside `tokio::select!` would trigger a hot loop and burn CPU.

The solution I used here was to refresh the handles at the end of a spam run. If a user doesn't want to do another spam run, they should be able to just drop the entire `Contender` instance and all the handles will be dropped.

We also had to refactor the `CancellationToken` handling for `TestScenario`. (See breaking changes below). To remove a session mid-initialization, we need to have the cancellation token before/while we initialize `Contender`. We place this in `ContenderCtx` and give it to `TestScenario`, which creates a "child token", which means it can cancel tasks internally (which it does at the end of a spam run) without cancelling the parent context. With the "parent token" owned by `ContenderCtx`, we're able to propagate the cancel signal all the way down to `TxActor` (keeps track of pending txs, monitors for receipts).

Also added an optional `tokio-metrics` feature, and refactored `flush_loop` for better cancellation detection.

### Breaking changes

- `TestScenario::new` now requires an additional parameter: `cancel_token: CancellationToken`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [x] Ran `cargo +nightly clippy --workspace --lib --examples --tests --benches --all-features --locked --fix`
- [x] Ran `cargo fmt --all`
- [x] Note breaking changes in PR description, if applicable
- [x] update changelogs
    - [x] Update `CHANGELOG.md` in each affected crate
    - [x] add a high-level description in the [root changelog](../CHANGELOG.md)
