### PR TITLE
per-crate versions

### DIFF
--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - 'v*'
+      - 'contender_cli_v*'
 
 permissions:
   contents: write
@@ -32,7 +32,14 @@ jobs:
         run: |
           platform=${{ matrix.config.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          # Extract version part after last underscore
+          ver="${GITHUB_REF#refs/*/}"
+          ver="${ver##*_}"
+          # Ensure it starts with 'v'
+          if [[ "$ver" != v* ]]; then
+            ver="v$ver"
+          fi
+          echo "RELEASE_VERSION=$ver" >> $GITHUB_ENV
 
       - name: Print version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ name: release
 on:
   push:
     tags:
-      - v*
+      - contender_cli_v*
   workflow_dispatch:
     inputs:
       dry_run:
@@ -37,6 +37,12 @@ jobs:
         run: |
           vv="${GITHUB_REF_NAME}"
           vv="${vv//\//-}"
+          # Extract version part after the last underscore
+          vv="${vv##*_}"
+          # Ensure it starts with 'v'
+          if [[ "$vv" != v* ]]; then
+            vv="v$vv"
+          fi
           echo "VERSION=$vv" >> $GITHUB_OUTPUT
         id: extract_version
     outputs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.10.0"
 rust-version = "1.86"
 authors = ["Flashbots"]
 license = "MIT OR Apache-2.0"

--- a/crates/bundle_provider/Cargo.toml
+++ b/crates/bundle_provider/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "contender_bundle_provider"
-version.workspace = true
+description = "Contender bundle provider"
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
-description = "Contender bundle provider"
 
 [dependencies]
 alloy = { workspace = true, features = ["node-bindings", "rpc-types-mev"] }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "contender_cli"
-version.workspace = true
+description = "Contender CLI"
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
-description = "Contender CLI"
 
 [[bin]]
 name = "contender"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "contender_core"
-version.workspace = true
+description = "Contender core library"
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
-description = "Contender core library"
 
 [dependencies]
 contender_bundle_provider = { workspace = true }

--- a/crates/engine_provider/Cargo.toml
+++ b/crates/engine_provider/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "contender_engine_provider"
-version.workspace = true
+description = "Contender engine_ API provider"
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
-description = "Contender engine_ API provider"
 
 [lib]
 name = "contender_engine_provider"

--- a/crates/report/Cargo.toml
+++ b/crates/report/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "contender_report"
-version.workspace = true
+description = "Generate reports to analyze chain performance and orderflow from contender spam runs."
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/sqlite_db/Cargo.toml
+++ b/crates/sqlite_db/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
+name = "contender_sqlite"
+description = "SQLite database for contender"
+version = "0.10.0"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-name = "contender_sqlite"
-description = "SQLite database for contender"
 repository.workspace = true
 rust-version.workspace = true
-version.workspace = true
 
 [dependencies]
 alloy = { workspace = true }

--- a/crates/testfile/Cargo.toml
+++ b/crates/testfile/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "contender_testfile"
-version.workspace = true
+description = "Definitions for contender scenarios to be encoded as TOML files."
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
-description = "Definitions for contender scenarios to be encoded as TOML files."
 
 [dependencies]
 toml = { workspace = true }

--- a/docs/library-usage.md
+++ b/docs/library-usage.md
@@ -1,14 +1,19 @@
 # Using Contender as a library
 
-Add crates you need:
+
+Add crates you need (using the new per-crate tag scheme):
 ```toml
 [dependencies]
-contender_core   = { git = "https://github.com/flashbots/contender" }
-contender_sqlite = { git = "https://github.com/flashbots/contender" }
-contender_testfile = { git = "https://github.com/flashbots/contender" }
+# Use the new tag format: <crate>_v<version>
+contender_core   = { git = "https://github.com/flashbots/contender", tag = "contender_core_v0.11.0" }
+contender_sqlite = { git = "https://github.com/flashbots/contender", tag = "contender_sqlite_v0.10.0" }
+contender_testfile = { git = "https://github.com/flashbots/contender", tag = "contender_testfile_v0.10.1" }
 
 # recommended
 tokio = { version = "1.40.0", features = ["rt-multi-thread"] }
 ```
+
+> **Note:**
+> Each crate is now versioned and tagged individually. Use the tag format `<crate>_v<version>` for the crate you want to depend on. For example, to use version 0.10.1 of `contender_core`, use `tag = "contender_core_v0.10.1"`.
 
 Example of contender being used as a library: [op-interop-contender](https://github.com/zeroxbrock/op-interop-contender)

--- a/scripts/2_tag-version.sh
+++ b/scripts/2_tag-version.sh
@@ -128,19 +128,6 @@ undoVersionChange() {
         echo "Reverted $CRATE version back to $CURRENT_VERSION in $CARGO_TOML"
 }
 
-echo """Please confirm that the following tasks have been performed:
-        - run 1_change-version.sh for $CRATE
-        - check Cargo.lock to make sure the versions have been updated (run 'cargo build' if they haven't)
-        - push changes to a new 'release/' branch
-        - create & merge a PR w/ the new version changes
-        - ensure $CRATE version in Cargo.toml is $NEW_VERSION
-"""
-confirm "Have you completed all the above tasks?"
-if [ $confirmed -ne 1 ]; then
-    undoVersionChange
-    exit 1
-fi
-
 echo "Enter a message to attach to the tag. Press Enter twice to finish or CTRL-C to quit:"
 TAG_MESSAGE=""
 while true; do
@@ -154,7 +141,7 @@ done
 if [ -z "$TAG_MESSAGE" ]; then
         echo "No message entered. Aborting."
         undoVersionChange
-        exit 2
+        exit 1
 fi
 
 git tag -a "$TAG" -m "$(echo -e "$TAG_MESSAGE")"
@@ -164,7 +151,7 @@ if [ $confirmed -ne 1 ]; then
     git tag -d "$TAG"
     echo "Tag $TAG deleted locally. Aborting push."
     undoVersionChange
-    exit 3
+    exit 1
 fi
 
 git push origin "$TAG"

--- a/scripts/2_tag-version.sh
+++ b/scripts/2_tag-version.sh
@@ -4,40 +4,48 @@
 set -e
 
 
-# Enumerate crates from crates/ directory (kebab-case)
+
+# Enumerate crates by package name and map to their directory (POSIX-compatible)
 CRATES_DIR="/Users/brock/code/contender/crates"
-CRATES=""
-CRATE_ARR=()
+PKG_ARR=()
+DIR_ARR=()
 for dir in "$CRATES_DIR"/*/; do
     [ -d "$dir" ] || continue
-    crate_name=$(basename "$dir")
-    CRATE_ARR+=("$crate_name")
+    CARGO_TOML="$dir/Cargo.toml"
+    if [ -f "$CARGO_TOML" ]; then
+        PKG_NAME=$(grep '^name =' "$CARGO_TOML" | head -n1 | sed -E 's/name = "([^"]+)"/\1/')
+        if [ -n "$PKG_NAME" ]; then
+            PKG_ARR+=("$PKG_NAME")
+            DIR_ARR+=("${dir%/}")
+        fi
+    fi
 done
 
-if [ ${#CRATE_ARR[@]} -eq 0 ]; then
+if [ ${#PKG_ARR[@]} -eq 0 ]; then
     echo "No crates found in $CRATES_DIR"
     exit 1
 fi
 
-echo "Select a crate to tag:"
-select CRATE in "${CRATE_ARR[@]}"; do
+echo "Select a crate to tag (by package name):"
+select CRATE in "${PKG_ARR[@]}"; do
     if [ -n "$CRATE" ]; then
+        IDX=$((REPLY-1))
+        CRATE_DIR="${DIR_ARR[$IDX]}"
+        # Remove trailing slash if present
+        CRATE_DIR="${CRATE_DIR%/}"
+        CARGO_TOML="$CRATE_DIR/Cargo.toml"
+        if [ ! -f "$CARGO_TOML" ]; then
+            echo "Cargo.toml not found for crate $CRATE"
+            echo "Checked path: $CARGO_TOML"
+            echo "Directory contents:"
+            ls -l "$CRATE_DIR"
+            exit 1
+        fi
         break
     fi
 done
 
 
-# Map crate to directory
-CRATE_DIR="/Users/brock/code/contender/crates/${CRATE//-/_}"
-if [ ! -d "$CRATE_DIR" ]; then
-    # fallback for kebab-case dirs
-    CRATE_DIR="/Users/brock/code/contender/crates/$CRATE"
-fi
-CARGO_TOML="$CRATE_DIR/Cargo.toml"
-if [ ! -f "$CARGO_TOML" ]; then
-    echo "Cargo.toml not found for crate $CRATE"
-    exit 1
-fi
 
 # Extract current version
 CURRENT_VERSION=$(grep '^version' "$CARGO_TOML" | head -n1 | sed -E 's/version *= *"([0-9]+\.[0-9]+\.[0-9]+)"/\1/')
@@ -45,6 +53,7 @@ if [[ ! "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     echo "Could not determine current version for $CRATE"
     exit 1
 fi
+
 
 # Preview version bumps for the selected crate
 IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
@@ -86,51 +95,37 @@ while true; do
     esac
 done
 
-# Map crate to directory
-CRATE_DIR="/Users/brock/code/contender/crates/${CRATE//-/_}"
-if [ ! -d "$CRATE_DIR" ]; then
-    # fallback for kebab-case dirs
-    CRATE_DIR="/Users/brock/code/contender/crates/$CRATE"
-fi
-CARGO_TOML="$CRATE_DIR/Cargo.toml"
-if [ ! -f "$CARGO_TOML" ]; then
-    echo "Cargo.toml not found for crate $CRATE"
-    exit 1
-fi
 
-# Extract current version
-CURRENT_VERSION=$(grep '^version' "$CARGO_TOML" | head -n1 | sed -E 's/version *= *"([0-9]+\.[0-9]+\.[0-9]+)"/\1/')
-if [[ ! "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "Could not determine current version for $CRATE"
-    exit 1
+# Update the version in the selected crate's Cargo.toml (after bump selection)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' "s/^version = \".*\"/version = \"$NEW_VERSION\"/" "$CARGO_TOML"
+else
+    sed -i "s/^version = \".*\"/version = \"$NEW_VERSION\"/" "$CARGO_TOML"
 fi
+echo "Updated $CRATE version to $NEW_VERSION in $CARGO_TOML"
 
-# Calculate new version
-IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
-case "$BUMP" in
-    patch)
-        PATCH=$((PATCH + 1))
-        ;;
-    minor)
-        MINOR=$((MINOR + 1))
-        PATCH=0
-        ;;
-    major)
-        MAJOR=$((MAJOR + 1))
-        MINOR=0
-        PATCH=0
-        ;;
-esac
-NEW_VERSION="$MAJOR.$MINOR.$PATCH"
 TAG="${CRATE}_v${NEW_VERSION}"
 echo "Will create tag: $TAG"
+
+confirmed=0
 
 confirm() {
         read -p "$1 (y/N): " confirm
         if [[ ! "$confirm" =~ ^[Yy] ]]; then
                 echo "Aborting."
-                exit 1
+                confirmed=0
+        else
+                confirmed=1
         fi
+}
+
+undoVersionChange() {
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+                sed -i '' "s/^version = \".*\"/version = \"$CURRENT_VERSION\"/" "$CARGO_TOML"
+        else
+                sed -i "s/^version = \".*\"/version = \"$CURRENT_VERSION\"/" "$CARGO_TOML"
+        fi
+        echo "Reverted $CRATE version back to $CURRENT_VERSION in $CARGO_TOML"
 }
 
 echo """Please confirm that the following tasks have been performed:
@@ -141,6 +136,10 @@ echo """Please confirm that the following tasks have been performed:
         - ensure $CRATE version in Cargo.toml is $NEW_VERSION
 """
 confirm "Have you completed all the above tasks?"
+if [ $confirmed -ne 1 ]; then
+    undoVersionChange
+    exit 1
+fi
 
 echo "Enter a message to attach to the tag. Press Enter twice to finish or CTRL-C to quit:"
 TAG_MESSAGE=""
@@ -154,48 +153,18 @@ done
 
 if [ -z "$TAG_MESSAGE" ]; then
         echo "No message entered. Aborting."
-        exit 1
+        undoVersionChange
+        exit 2
 fi
 
 git tag -a "$TAG" -m "$(echo -e "$TAG_MESSAGE")"
 
 confirm "Do you want to push this tag to the remote origin?"
-
-git push origin "$TAG"
-
-confirm() {
-    read -p "$1 (y/N): " confirm
-    if [[ ! "$confirm" =~ ^[Yy] ]]; then
-        echo "Aborting."
-        exit 1
-    fi
-}
-
-echo """Please confirm that the following tasks have been performed:
-    - run 1_change-version.sh
-    - check Cargo.lock to make sure the versions have been updated (run 'cargo build' if they haven't)
-    - push changes to a new 'release/' branch
-    - create & merge a PR w/ the new version changes
-"""
-confirm "Have you completed all the above tasks?"
-
-echo "Enter a message to attach to the tag. Press Enter twice to finish or CTRL-C to quit:"
-TAG_MESSAGE=""
-while true; do
-    IFS= read -r line
-    if [ -z "$line" ]; then
-        break
-    fi
-    TAG_MESSAGE="${TAG_MESSAGE}${line}\n"
-done
-
-if [ -z "$TAG_MESSAGE" ]; then
-    echo "No message entered. Aborting."
-    exit 1
+if [ $confirmed -ne 1 ]; then
+    git tag -d "$TAG"
+    echo "Tag $TAG deleted locally. Aborting push."
+    undoVersionChange
+    exit 3
 fi
-
-git tag -a "$TAG" -m "$(echo -e "$TAG_MESSAGE")"
-
-confirm "Do you want to push this tag to the remote origin?"
 
 git push origin "$TAG"

--- a/scripts/2_tag-version.sh
+++ b/scripts/2_tag-version.sh
@@ -1,19 +1,167 @@
 #!/bin/bash
 
+
 set -e
 
-if [ -z "$1" ]; then
-    echo "Usage: $0 <tag>"
+
+# Enumerate crates from crates/ directory (kebab-case)
+CRATES_DIR="/Users/brock/code/contender/crates"
+CRATES=""
+CRATE_ARR=()
+for dir in "$CRATES_DIR"/*/; do
+    [ -d "$dir" ] || continue
+    crate_name=$(basename "$dir")
+    CRATE_ARR+=("$crate_name")
+done
+
+if [ ${#CRATE_ARR[@]} -eq 0 ]; then
+    echo "No crates found in $CRATES_DIR"
     exit 1
 fi
 
-TAG="$1"
-echo "tag: $TAG"
+echo "Select a crate to tag:"
+select CRATE in "${CRATE_ARR[@]}"; do
+    if [ -n "$CRATE" ]; then
+        break
+    fi
+done
 
-if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "Error: Tag must start with 'v' and follow semantic versioning (e.g., v1.2.3)"
+
+# Map crate to directory
+CRATE_DIR="/Users/brock/code/contender/crates/${CRATE//-/_}"
+if [ ! -d "$CRATE_DIR" ]; then
+    # fallback for kebab-case dirs
+    CRATE_DIR="/Users/brock/code/contender/crates/$CRATE"
+fi
+CARGO_TOML="$CRATE_DIR/Cargo.toml"
+if [ ! -f "$CARGO_TOML" ]; then
+    echo "Cargo.toml not found for crate $CRATE"
     exit 1
 fi
+
+# Extract current version
+CURRENT_VERSION=$(grep '^version' "$CARGO_TOML" | head -n1 | sed -E 's/version *= *"([0-9]+\.[0-9]+\.[0-9]+)"/\1/')
+if [[ ! "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Could not determine current version for $CRATE"
+    exit 1
+fi
+
+# Preview version bumps for the selected crate
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+PATCH_NEXT=$((PATCH + 1))
+MINOR_NEXT=$((MINOR + 1))
+MAJOR_NEXT=$((MAJOR + 1))
+
+PATCH_VERSION="v$MAJOR.$MINOR.$PATCH_NEXT"
+MINOR_VERSION="v$MAJOR.$MINOR_NEXT.0"
+MAJOR_VERSION="v$MAJOR_NEXT.0.0"
+
+echo "Current version: v$CURRENT_VERSION"
+echo "Select version bump type:"
+echo "1) patch -> $PATCH_VERSION"
+echo "2) minor -> $MINOR_VERSION"
+echo "3) major -> $MAJOR_VERSION"
+
+while true; do
+    read -p "Enter choice [1-3]: " bump_choice
+    case $bump_choice in
+        1|patch)
+            BUMP="patch"
+            NEW_VERSION="${PATCH_VERSION#v}"
+            break
+            ;;
+        2|minor)
+            BUMP="minor"
+            NEW_VERSION="${MINOR_VERSION#v}"
+            break
+            ;;
+        3|major)
+            BUMP="major"
+            NEW_VERSION="${MAJOR_VERSION#v}"
+            break
+            ;;
+        *)
+            echo "Invalid choice. Please enter 1, 2, or 3."
+            ;;
+    esac
+done
+
+# Map crate to directory
+CRATE_DIR="/Users/brock/code/contender/crates/${CRATE//-/_}"
+if [ ! -d "$CRATE_DIR" ]; then
+    # fallback for kebab-case dirs
+    CRATE_DIR="/Users/brock/code/contender/crates/$CRATE"
+fi
+CARGO_TOML="$CRATE_DIR/Cargo.toml"
+if [ ! -f "$CARGO_TOML" ]; then
+    echo "Cargo.toml not found for crate $CRATE"
+    exit 1
+fi
+
+# Extract current version
+CURRENT_VERSION=$(grep '^version' "$CARGO_TOML" | head -n1 | sed -E 's/version *= *"([0-9]+\.[0-9]+\.[0-9]+)"/\1/')
+if [[ ! "$CURRENT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Could not determine current version for $CRATE"
+    exit 1
+fi
+
+# Calculate new version
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+case "$BUMP" in
+    patch)
+        PATCH=$((PATCH + 1))
+        ;;
+    minor)
+        MINOR=$((MINOR + 1))
+        PATCH=0
+        ;;
+    major)
+        MAJOR=$((MAJOR + 1))
+        MINOR=0
+        PATCH=0
+        ;;
+esac
+NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+TAG="${CRATE}_v${NEW_VERSION}"
+echo "Will create tag: $TAG"
+
+confirm() {
+        read -p "$1 (y/N): " confirm
+        if [[ ! "$confirm" =~ ^[Yy] ]]; then
+                echo "Aborting."
+                exit 1
+        fi
+}
+
+echo """Please confirm that the following tasks have been performed:
+        - run 1_change-version.sh for $CRATE
+        - check Cargo.lock to make sure the versions have been updated (run 'cargo build' if they haven't)
+        - push changes to a new 'release/' branch
+        - create & merge a PR w/ the new version changes
+        - ensure $CRATE version in Cargo.toml is $NEW_VERSION
+"""
+confirm "Have you completed all the above tasks?"
+
+echo "Enter a message to attach to the tag. Press Enter twice to finish or CTRL-C to quit:"
+TAG_MESSAGE=""
+while true; do
+        IFS= read -r line
+        if [ -z "$line" ]; then
+                break
+        fi
+        TAG_MESSAGE="${TAG_MESSAGE}${line}\n"
+done
+
+if [ -z "$TAG_MESSAGE" ]; then
+        echo "No message entered. Aborting."
+        exit 1
+fi
+
+git tag -a "$TAG" -m "$(echo -e "$TAG_MESSAGE")"
+
+confirm "Do you want to push this tag to the remote origin?"
+
+git push origin "$TAG"
 
 confirm() {
     read -p "$1 (y/N): " confirm


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/flashbots/contender/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

Each crate was deriving its version from the workspace, but crates have their own dependency graphs and locally- (or downstream)-breaking changes that may not reflect the CLI (the binary release).

Making a breaking change in contender_core doesn't mean that the cli has a breaking change. To the cli, that's a patch.

for example: the current unreleased set of changes includes one breaking feature in `contender_core`, but it doesn't actually affect the code in `contender_cli`. So `contender_core` should switch to `v0.11.0` and `contender_cli` (because it relies on `contender_core` but doesn't introduce any breaking changes to its users) should switch to `v0.10.1` (which will happen in a PR following this one).

## Solution

- version each crate independently; stop using `version.workspace = true`
- revise the release scripts (remove script 1 and update script 2) to create tags for individually versioning crates
- update the release workflows to account for the new tag scheme

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Ran `cargo +nightly clippy --workspace --lib --examples --tests --benches --all-features --locked --fix`
- [ ] Ran `cargo fmt --all`
- [ ] Note breaking changes in PR description, if applicable
- [ ] update changelogs
    - [ ] Update `CHANGELOG.md` in each affected crate
    - [ ] add a high-level description in the [root changelog](../CHANGELOG.md)
