### PR TITLE
remove trailing slashes from workspace members & path deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [workspace]
 members = [
     "crates/bundle_provider",
-    "crates/cli/",
-    "crates/core/",
+    "crates/cli",
+    "crates/core",
     "crates/engine_provider",
     "crates/report",
-    "crates/sqlite_db/",
-    "crates/testfile/",
+    "crates/sqlite_db",
+    "crates/testfile",
 ]
 
 resolver = "2"
@@ -21,12 +21,12 @@ repository = "https://github.com/flashbots/contender"
 
 [workspace.dependencies]
 contender_cli = { path = "crates/cli" }
-contender_core = { path = "crates/core/" }
-contender_sqlite = { path = "crates/sqlite_db/" }
-contender_testfile = { path = "crates/testfile/" }
-contender_bundle_provider = { path = "crates/bundle_provider/" }
-contender_engine_provider = { path = "crates/engine_provider/" }
-contender_report = { path = "crates/report/" }
+contender_core = { path = "crates/core" }
+contender_sqlite = { path = "crates/sqlite_db" }
+contender_testfile = { path = "crates/testfile" }
+contender_bundle_provider = { path = "crates/bundle_provider" }
+contender_engine_provider = { path = "crates/engine_provider" }
+contender_report = { path = "crates/report" }
 
 tokio = { version = "1.40.0" }
 tokio-metrics = { version = "0.5.0" }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/flashbots/contender/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

dependabot security patches are breaking with the following error:

```
Dependabot can't resolve your Rust dependency files
Dependabot failed to update your dependencies because there was an error resolving your Rust dependency files.

Dependabot encountered the following error:

error: failed to parse manifest at `dependabot_tmp_dir/crates/cli/Cargo.toml`

Caused by:
  error inheriting `edition` from workspace root manifest's `workspace.package.edition`

Caused by:
  failed to find a workspace root
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

remove trailing slashes so dependabot can parse the manifest correctly

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Ran `cargo +nightly clippy --workspace --lib --examples --tests --benches --all-features --locked --fix`
- [ ] Ran `cargo fmt --all`
- [ ] Note breaking changes in PR description, if applicable
- [ ] update changelogs
    - [ ] Update `CHANGELOG.md` in each affected crate
    - [ ] add a high-level description in the [root changelog](../CHANGELOG.md)
