### PR TITLE
chore: bump versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-> Note: this file did not exist until after `v0.5.6`.
-
-## Unreleased
-
-- replaced interval-based spammer refunding with a per-batch balance check, preventing over-funding on long `--forever` runs ([#514](https://github.com/flashbots/contender/issues/514))
-- (rpc): fix CPU usage bugs ([#527](https://github.com/flashbots/contender/pull/527/changes))
+> Note: contender is now versioned by crate. This file will no longer be updated. Please check the [contender_core CHANGELOG](./crates/core/CHANGELOG.md) for updates on the terminal application.
 
 ## [0.10.0](https://github.com/flashbots/contender/releases/tag/v0.10.0) - 2026-04-20
 
@@ -115,3 +110,7 @@ Internal changes:
 - revamp error handling ([#378](https://github.com/flashbots/contender/pull/378))
 - DB schema bumped to `user_version = 6` to record campaign/stage metadata in runs.
   - If you see a DB version mismatch, export/reset your DB: `contender db export` (optional backup) then `contender db reset` (or `drop`) to recreate with the new schema.
+
+---
+
+> Note: this file did not exist until after `v0.5.6`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2150,7 +2150,7 @@ dependencies = [
 
 [[package]]
 name = "contender_cli"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "alloy",
  "async-trait",
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "contender_core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "ark-bn254",
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "contender_report"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "alloy",
  "chrono",
@@ -2264,7 +2264,7 @@ dependencies = [
 
 [[package]]
 name = "contender_sqlite"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "alloy",
  "contender_core",
@@ -2278,7 +2278,7 @@ dependencies = [
 
 [[package]]
 name = "contender_testfile"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "alloy",
  "contender_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2221,7 +2221,7 @@ dependencies = [
 
 [[package]]
 name = "contender_engine_provider"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "alloy",
  "alloy-json-rpc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "contender_bundle_provider"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "alloy",
  "serde",

--- a/crates/bundle_provider/CHANGELOG.md
+++ b/crates/bundle_provider/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1](https://github.com/flashbots/contender/releases/tag/v0.7.0) - 2026-05-05
+
+- update alloy dependencies ([#561](https://github.com/flashbots/contender/pull/561))
+
 ## [0.6.0](https://github.com/flashbots/contender/releases/tag/v0.6.0) - 2025-11-25
 
 - simplified `BundleProviderError`

--- a/crates/bundle_provider/Cargo.toml
+++ b/crates/bundle_provider/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "contender_bundle_provider"
 description = "Contender bundle provider"
-version = "0.10.0"
+version = "0.10.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -5,10 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.10.1](https://github.com/flashbots/contender/releases/tag/v0.7.0) - 2026-05-05
 
+- update alloy dependencies ([#561](https://github.com/flashbots/contender/pull/561))
+- update contender_core ([#565](https://github.com/flashbots/contender/pull/565))
 - replaced timed `--forever` auto-funding with per-batch balance-checked funding: spammer accounts are now refilled at the end of each batch whenever any account drops within 25% of `--min-balance`, avoiding the gradual over-funding the interval-based approach caused on long runs ([#514](https://github.com/flashbots/contender/issues/514))
 - (rpc): fix CPU usage bugs ([#527](https://github.com/flashbots/contender/pull/527/changes))
+- send txs to custom endpoint with --txs-url ([#534](https://github.com/flashbots/contender/pull/534))
 
 ## [0.10.0](https://github.com/flashbots/contender/releases/tag/v0.10.0) - 2026-04-20
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "contender_cli"
 description = "Contender CLI"
-version = "0.10.0"
+version = "0.10.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/cli/src/server/static/openrpc.json
+++ b/crates/cli/src/server/static/openrpc.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Contender RPC Server",
     "description": "JSON-RPC API to remotely run contender sessions.",
-    "version": "0.10.0"
+    "version": "0.10.1"
   },
   "x-source": {
     "repository": "https://github.com/flashbots/contender",

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.10.1](https://github.com/flashbots/contender/releases/tag/v0.7.0) - 2026-05-05
 
+- update alloy dependencies ([#561](https://github.com/flashbots/contender/pull/561))
 - (rpc): fix CPU usage bugs ([#527](https://github.com/flashbots/contender/pull/527/changes))
+- send txs to custom endpoint with --txs-url ([#534](https://github.com/flashbots/contender/pull/534))
 
 ### Breaking changes
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "contender_core"
 description = "Contender core library"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/engine_provider/CHANGELOG.md
+++ b/crates/engine_provider/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1](https://github.com/flashbots/contender/releases/tag/v0.7.0) - 2026-05-05
+
+- update alloy dependencies ([#561](https://github.com/flashbots/contender/pull/561))
+
 ## [0.7.1](https://github.com/flashbots/contender/releases/tag/v0.7.1) - 2026-01-09
 
 ### Breaking changes

--- a/crates/engine_provider/Cargo.toml
+++ b/crates/engine_provider/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "contender_engine_provider"
 description = "Contender engine_ API provider"
-version = "0.10.0"
+version = "0.10.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/report/CHANGELOG.md
+++ b/crates/report/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1](https://github.com/flashbots/contender/releases/tag/v0.7.0) - 2026-05-05
+
+- update alloy dependencies ([#561](https://github.com/flashbots/contender/pull/561))
+- update contender_core ([#565](https://github.com/flashbots/contender/pull/565))
+
 ## [0.10.0](https://github.com/flashbots/contender/releases/tag/v0.10.0) - 2026-04-20
 
 - added `total_txs`, `successful_txs`, and `failed_txs` fields to `SpamRunMetrics`; failure rate rendered as description on `failed_txs`

--- a/crates/report/Cargo.toml
+++ b/crates/report/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "contender_report"
 description = "Generate reports to analyze chain performance and orderflow from contender spam runs."
-version = "0.10.0"
+version = "0.10.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/sqlite_db/CHANGELOG.md
+++ b/crates/sqlite_db/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1](https://github.com/flashbots/contender/releases/tag/v0.7.0) - 2026-05-05
+
+- update alloy dependencies ([#561](https://github.com/flashbots/contender/pull/561))
+- update contender_core ([#565](https://github.com/flashbots/contender/pull/565))
+
 ## [0.9.0](https://github.com/flashbots/contender/releases/tag/v0.9.0) - 2026-03-17
 
 - use `impl AsRef<Path>` instead of `&str` for `SqliteDb::from_file` ([453](https://github.com/flashbots/contender/pull/453/changes))

--- a/crates/sqlite_db/Cargo.toml
+++ b/crates/sqlite_db/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "contender_sqlite"
 description = "SQLite database for contender"
-version = "0.10.0"
+version = "0.10.1"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/testfile/CHANGELOG.md
+++ b/crates/testfile/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1](https://github.com/flashbots/contender/releases/tag/v0.7.0) - 2026-05-05
+
+- update alloy dependencies ([#561](https://github.com/flashbots/contender/pull/561))
+
 ## [0.7.0](https://github.com/flashbots/contender/releases/tag/v0.7.0) - 2026-01-05
 
 - added support for campaigns ([#389](https://github.com/flashbots/contender/pull/389))

--- a/crates/testfile/Cargo.toml
+++ b/crates/testfile/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "contender_testfile"
 description = "Definitions for contender scenarios to be encoded as TOML files."
-version = "0.10.0"
+version = "0.10.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
transitioned from uniform workspace versioning to per-crate versioning, so we don't have to do a minor-version cli release every time we change one of its dependencies (which happens a lot).

contender_core-v0.11.0
contender_cli-v0.10.1
contender_report-v0.10.1
contender_sqlite-v0.10.1
contender_testfile-v0.10.1
contender_engine_provider-v0.10.1
contender_bundle_provider-v0.10.1

- [x] update changelogs
