### PR TITLE
release/v0.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "contender_cli"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "alloy",
  "async-trait",
@@ -2148,7 +2148,7 @@ dependencies = [
 
 [[package]]
 name = "contender_core"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "alloy",
  "ark-bn254",
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "contender_report"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "alloy",
  "chrono",
@@ -2218,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "contender_sqlite"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "alloy",
  "contender_core",
@@ -2232,7 +2232,7 @@ dependencies = [
 
 [[package]]
 name = "contender_testfile"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "alloy",
  "contender_core",

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.2](https://github.com/flashbots/contender/releases/tag/v0.10.2) - 2026-06-11
+
+- Add scenario access list support with placeholder resolution ([#588](https://github.com/flashbots/contender/pull/588))
+- spam-stream subcommand for streaming tx specs (relayer use case) ([#589](https://github.com/flashbots/contender/pull/589))
+- upgrade contender_core to [v0.11.1](../core/CHANGELOG.md)
+
 ## [0.10.1](https://github.com/flashbots/contender/releases/tag/v0.10.1) - 2026-05-06
 
 - update alloy dependencies ([#561](https://github.com/flashbots/contender/pull/561))

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "contender_cli"
 description = "Contender CLI"
-version = "0.10.1"
+version = "0.10.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/cli/src/server/static/openrpc.json
+++ b/crates/cli/src/server/static/openrpc.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Contender RPC Server",
     "description": "JSON-RPC API to remotely run contender sessions.",
-    "version": "0.10.1"
+    "version": "0.10.2"
   },
   "x-source": {
     "repository": "https://github.com/flashbots/contender",

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.11.1](https://github.com/flashbots/contender/releases/tag/contender_core-v0.11.1) - 2026-06-11
+
+*from [#580](https://github.com/flashbots/contender/pull/580):*
 
 - added `FunctionCallDefinition::max_priority_fee_per_gas` for setting a static (or `{placeholder}`-driven) per-tx EIP-1559 priority fee
 - added `FuzzParam::max_priority_fee_per_gas` (a bool flag mirroring `FuzzParam::value`) so the priority fee can be fuzzed per-tx alongside function args and `value`

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "contender_core"
 description = "Contender core library"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/report/Cargo.toml
+++ b/crates/report/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "contender_report"
 description = "Generate reports to analyze chain performance and orderflow from contender spam runs."
-version = "0.10.1"
+version = "0.10.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/sqlite_db/Cargo.toml
+++ b/crates/sqlite_db/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "contender_sqlite"
 description = "SQLite database for contender"
-version = "0.10.1"
+version = "0.10.2"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/testfile/Cargo.toml
+++ b/crates/testfile/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "contender_testfile"
 description = "Definitions for contender scenarios to be encoded as TOML files."
-version = "0.10.1"
+version = "0.10.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## crate versions

`contender_core` set to `v0.11.1`
dependent crates set to `v0.10.2`:
- `contender_cli`
- `contender_report`
- `contender_sqlite`
- `contender_testfile`

## included features

- #580
- #588 
- #589 