### PR TITLE
fix check-version CI script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,10 @@ jobs:
         run: |
           tag="${{ needs.extract-version.outputs.VERSION }}"
           tag=${tag#v}
-          cargo_ver=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          # WARNING: VERY SHITTY VERSION EXTRACTION, PLEASE FIX
+          # packages[1] is contender_cli, which is the primary user-facing crate.
+          # For this check, we focus on this crate only. Probably needs to be more robust, though.
+          cargo_ver=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[1].version')
           [[ "$tag" == "$cargo_ver"* ]] || { echo "Tag $tag doesn’t match the Cargo version $cargo_ver"; exit 1; }
 
   build:


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/flashbots/contender/blob/main/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

now that we're not using workspace versioning, `packages[0]` resolves to `contender_bundle_provider`, which is not what we want to check for this release process. We want to check `contender_cli`, which is `packages[1]` now.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

it's a kludge but I just changed the target to `packages[1]`. This whole system needs to be replaced.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Ran `cargo +nightly clippy --workspace --lib --examples --tests --benches --all-features --locked --fix`
- [ ] Ran `cargo fmt --all`
- [ ] Note breaking changes in PR description, if applicable
- [ ] update changelogs
    - [ ] Update `CHANGELOG.md` in each affected crate
    - [ ] add a high-level description in the [root changelog](../CHANGELOG.md)
